### PR TITLE
Remove unnecessary masking in test

### DIFF
--- a/test/TestServer.hs
+++ b/test/TestServer.hs
@@ -172,7 +172,7 @@ testProtocolServerBasicEcho = withListen' $ \(lsock, laddr) ->
 testProtocolServerClosesGracefully =
   do
     addrV <- newEmptyMVar
-    a <- async $ withListen' $ \(lsock, laddr) -> E.mask $ \restore -> do
+    a <- async $ withListen' $ \(lsock, laddr) -> do
         putMVar addrV laddr
         protocolServer lsock cat echo
     let kill = killThread (asyncThreadId a)


### PR DESCRIPTION
That (I think) stop the exception being thrown in the thread and therefore
causes a race when we issue `kill`.

I think `kill` blocks until the exception has been delivered. I.e., we know once
it returns that the other thread has handled it, but I'm not sure. This _does_
seem to have stopped it racing on my machine though. (Ran for 10 mins in a tight
loop.)