### PR TITLE
More efforts to optimise validation

### DIFF
--- a/src/Clapi/Relay.hs
+++ b/src/Clapi/Relay.hs
@@ -34,7 +34,7 @@ import Clapi.Tree (RoseTreeNode(..), TimeSeries)
 import Clapi.Valuespace
   ( Valuespace(..), vsRelinquish, vsLookupDef
   , processToRelayProviderDigest, processToRelayClientDigest, valuespaceGet
-  , getLiberty, rootTypeName, lookupDef)
+  , getLiberty, rootTypeName)
 import Clapi.Protocol (Protocol, waitThenFwdOnly, sendRev)
 
 mapPartitionJust :: Map k (Maybe a) -> (Map k a, Set k)
@@ -102,7 +102,7 @@ relay vs = waitThenFwdOnly fwd
             -- FIXME: Attributing revocation to nobody!
             (Map.singleton Root $ Map.singleton ns (Nothing, SoAbsent))
             (Map.insert
-              rootTypeName (OpDefine $ fromJust $ lookupDef rootTypeName $ vsTyDefs vs') $
+              rootTypeName (OpDefine $ fromJust $ vsLookupDef rootTypeName vs') $
               (fmap (const OpUndefine) $ Map.mapKeys (TypeName ns) $ Map.findWithDefault mempty ns $ vsTyDefs vs))
             mempty alEmpty mempty)
           relay vs'
@@ -113,7 +113,7 @@ relay vs = waitThenFwdOnly fwd
             shouldPubRoot =
               Map.member ns defs &&
               Map.notMember ns (vsTyDefs vs)
-            rootDef = fromJust $ lookupDef rootTypeName $ vsTyDefs vs'
+            rootDef = fromJust $ vsLookupDef rootTypeName vs'
             nsContOp (StructDef (StructDefinition _ kids)) = Map.singleton ns
               (Nothing, SoPresentAfter $ presentAfter ns $ alKeys kids)
             nsContOp _ = error "Root def not a struct WTAF"

--- a/src/Clapi/Relay.hs
+++ b/src/Clapi/Relay.hs
@@ -108,8 +108,7 @@ relay vs = waitThenFwdOnly fwd
           relay vs'
       where
         handleOwnerSuccess
-            (TrpDigest ns defs dd contOps errs)
-            (updatedTyAssns, vs'@(Valuespace _ _ tas)) =
+            (TrpDigest ns defs dd contOps errs) (updatedTyAssns, vs') =
           let
             shouldPubRoot =
               Map.member ns defs &&

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -25,8 +25,17 @@ import Clapi.Types.Wire (WireValue)
 data SubOp = OpSubscribe | OpUnsubscribe deriving (Show, Eq)
 data DefOp = OpDefine {odDef :: Definition} | OpUndefine deriving (Show, Eq)
 
+isUndef :: DefOp -> Bool
+isUndef OpUndefine = True
+isUndef _ = False
+
 data TimeSeriesDataOp =
   OpSet Time [WireValue] Interpolation | OpRemove deriving (Show, Eq)
+
+isRemove :: TimeSeriesDataOp -> Bool
+isRemove OpRemove = True
+isRemove _ = False
+
 data DataChange
   = ConstChange (Maybe Attributee) [WireValue]
   | TimeChange (Map Word32 (Maybe Attributee, TimeSeriesDataOp))

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -193,7 +193,8 @@ validatePath vs p = undefined -- do
     -- validateRoseTreeNode def t
 
 type RefTypeClaims = Mos TypeName Referee
-type TypeClaimsByPath = Map Referer (Either RefTypeClaims (Map TpId RefTypeClaims))
+type TypeClaimsByPath =
+  Map Referer (Either RefTypeClaims (Map TpId RefTypeClaims))
 
 partitionXrefs :: Xrefs -> TypeClaimsByPath -> (Xrefs, Xrefs)
 partitionXrefs oldXrefs claims = (preExistingXrefs, newXrefs)
@@ -206,9 +207,13 @@ partitionXrefs oldXrefs claims = (preExistingXrefs, newXrefs)
       Right rtcm -> Map.foldlWithKey (addRefererWithTpid referer) acc rtcm
     addReferer referer acc referee = Map.alter
       (Just . Map.insert referer Nothing . maybe mempty id) referee acc
-    addRefererWithTpid referer acc tpid rtcs = foldl (addRefererWithTpid' referer tpid) acc $ mosValues rtcs
+    addRefererWithTpid referer acc tpid rtcs =
+      foldl (addRefererWithTpid' referer tpid) acc $ mosValues rtcs
     addRefererWithTpid' referer tpid acc referee = Map.alter
-      (Just . Map.alter (Just . Just . maybe (Set.singleton tpid) (Set.insert tpid) . maybe Nothing id) referer . maybe mempty id)
+      (Just . Map.alter
+        (Just . Just . maybe (Set.singleton tpid) (Set.insert tpid) .
+          maybe Nothing id)
+        referer . maybe mempty id)
       referee
       acc
     preExistingXrefs = Map.foldlWithKey removeOldXrefs oldXrefs claims
@@ -418,7 +423,8 @@ validateExistingXrefs xrs newTas =
     refererErrors referee acc referer mTpids = case mTpids of
       Nothing -> Map.insert (PathError referer) (errText referee) acc
       Just tpids -> Set.foldl
-        (\acc' tpid -> Map.insert (TimePointError referer tpid) (errText referee) acc')
+        (\acc' tpid ->
+           Map.insert (TimePointError referer tpid) (errText referee) acc')
         acc tpids
     refereeErrs acc referee refererMap =
       Map.foldlWithKey (refererErrors referee) acc refererMap

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -48,8 +48,8 @@ import Clapi.Types.Definitions
   , StructDefinition(..), ArrayDefinition(..), defDispatch, childLibertyFor
   , childTypeFor)
 import Clapi.Types.Digests
-  ( DefOp(..), ContainerOps, DataChange(..), DataDigest, TrpDigest(..)
-  , trpdRemovedPaths)
+  ( DefOp(..), isUndef, ContainerOps, DataChange(..), isRemove, DataDigest
+  , TrpDigest(..), trpdRemovedPaths)
 import Clapi.Types.Messages (ErrorIndex(..))
 import Clapi.Types.Path
   (Seg, Path, pattern (:/), pattern Root, pattern (:</), TypeName(..))
@@ -286,10 +286,6 @@ processToRelayProviderDigest trpd vs =
       (Map.fromSet (const Nothing) redefdPaths <> updatedPaths) $
       Valuespace tree' defs' $ vsTyAssns vs
     return (updatedTypes, vs')
-  where
-    isUndef :: DefOp -> Bool
-    isUndef OpUndefine = True
-    isUndef _ = False
 
 processToRelayClientDigest
   :: ContainerOps -> DataDigest -> Valuespace -> Map Path [Text]

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -243,7 +243,7 @@ validateVs =
 
 processToRelayProviderDigest
   :: TrpDigest -> Valuespace
-  -> Either (Map (ErrorIndex TypeName) [Text]) Valuespace
+  -> Either (Map (ErrorIndex TypeName) [Text]) (Map Path TypeName, Valuespace)
 processToRelayProviderDigest trpd vs =
   let
     ns = trpdNamespace trpd
@@ -271,7 +271,7 @@ processToRelayProviderDigest trpd vs =
     (updatedTypes, vs') <- validateVs
       (Map.fromSet (const Nothing) redefdPaths <> updatedPaths) $
       Valuespace tree' defs' $ vsTyAssns vs
-    return vs'
+    return (updatedTypes, vs')
   where
     isUndef :: DefOp -> Bool
     isUndef OpUndefine = True

--- a/src/Data/Map/Mos.hs
+++ b/src/Data/Map/Mos.hs
@@ -62,6 +62,9 @@ type Dependencies k a = (Map.Map k a, Mos a k)
 dependenciesFromMap :: (Ord k, Ord a) => Map.Map k a -> Dependencies k a
 dependenciesFromMap m = (m, invertMap m)
 
+dependenciesFromList :: (Ord k, Ord a) => [(k, a)] -> Dependencies k a
+dependenciesFromList = dependenciesFromMap . Map.fromList
+
 getDependency :: (Ord k, Ord a) => k -> Dependencies k a -> Maybe a
 getDependency k = Map.lookup k . fst
 

--- a/test/Data/Map/MosSpec.hs
+++ b/test/Data/Map/MosSpec.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Data.Map.MosSpec where
 
 import Test.Hspec
+import Test.QuickCheck
 
 import qualified Data.Set as Set
 
+import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Map.Mos (Mos)
 import qualified Data.Map.Mos as Mos
 
 spec :: Spec
@@ -47,6 +52,15 @@ spec = do
         assertRevDeps 1  "b" ds2
         assertNoRevDeps 2 ds2
         ds3 `shouldBe` ds0
+    it "should stay correct under inversion" $ property $
+      \(input :: [(Char, Int)]) -> let mos = Mos.fromList input in
+        mos == Mos.invert (Mos.invert mos)
+    it "should roundtrip via set" $ property $
+      \(input :: [(Char, Int)]) -> let mos = Mos.fromList input in
+        mos == Mos.fromFoldable (Mos.toSet mos)
+    it "can be produced from a Map" $ property $
+      \(input :: Map Char Int) -> let mos = Mos.invertMap input in
+        fmap Set.singleton input == Mos.invert mos
 
 assertDep k a ds = Mos.getDependency k ds `shouldBe` Just a
 assertNoDep k ds = Mos.getDependency k ds `shouldBe` Nothing

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -25,8 +25,8 @@ import Clapi.Types.Definitions
   (structDef, tupleDef, Liberty(..))
 import Clapi.Types.Digests
   ( DefOp(..), DataChange(..), TrpDigest(..), trpDigest
-  , InboundDigest(..), InboundClientDigest(..), OutboundDigest(..), OutboundClientDigest(..)
-  , outboundClientDigest, TrprDigest(..))
+  , InboundDigest(..), InboundClientDigest(..), OutboundDigest(..)
+  , OutboundClientDigest(..), outboundClientDigest, TrprDigest(..))
 import Clapi.Types.SequenceOps (SequenceOp(..))
 import Clapi.Types.Messages (ErrorIndex(..))
 import Clapi.Types.Path (pattern Root, TypeName(..), pattern (:/))
@@ -59,7 +59,8 @@ spec = describe "the relay protocol" $ do
             ]
           , ocdTypeAssignments = Map.insert
             [pathq|/foo|] (TypeName foo foo, Cannot) mempty
-          , ocdContainerOps = Map.singleton Root $ Map.singleton foo (Nothing, SoPresentAfter (Just apiNs))
+          , ocdContainerOps = Map.singleton Root $
+              Map.singleton foo (Nothing, SoPresentAfter (Just apiNs))
           }
         test = do
           sendFwd ((), inDig)
@@ -80,7 +81,8 @@ spec = describe "the relay protocol" $ do
                 vsLookupDef rootTypeName baseValuespace)
             , (TypeName foo foo, OpUndefine)
             ]
-          , ocdContainerOps = Map.singleton Root $ Map.singleton foo (Nothing, SoAbsent)
+          , ocdContainerOps = Map.singleton Root $
+              Map.singleton foo (Nothing, SoAbsent)
           }
         test = do
           sendFwd ((), Iprd $ TrprDigest foo)
@@ -93,7 +95,8 @@ spec = describe "the relay protocol" $ do
           { ocdErrors = Map.singleton (PathError p) ["Path not found"]
           }
         test = do
-          sendFwd ((), Icd $ InboundClientDigest (Set.singleton p) mempty mempty alEmpty)
+          sendFwd ((), Icd $
+            InboundClientDigest (Set.singleton p) mempty mempty alEmpty)
           waitThenRevOnly $ lift . (`shouldBe` expectedOutDig) . snd
       in runEffect $ test <<-> relay baseValuespace
     it "should respond sensibly to data changes" $
@@ -110,7 +113,9 @@ spec = describe "the relay protocol" $ do
         dd = alSingleton Root $ ConstChange bob [WireValue (4 :: Word32)]
         test = do
             sendFwd ((), Ipd $ (trpDigest foo) {trpdData = dd})
-            waitThenRevOnly $ lift . (`shouldBe` Ocd (outboundClientDigest {ocdData = dd})) . snd
+            waitThenRevOnly $
+              lift . (`shouldBe` Ocd (outboundClientDigest {ocdData = dd})) .
+              snd
       in runEffect $ test <<-> relay vsWithInt
 
   where

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -36,8 +36,8 @@ import Clapi.Types.Tree (ttWord32, unbounded)
 import Clapi.Types.UniqList (ulEmpty, ulSingle)
 import Clapi.Types.Wire (WireValue(..))
 import Clapi.Valuespace
-  ( baseValuespace, unsafeValidateVs, apiNs, vsTyAssns, Valuespace(..)
-  , rootTypeName, lookupDef)
+  ( baseValuespace, unsafeValidateVs, apiNs, Valuespace(..)
+  , rootTypeName, vsLookupDef)
 
 spec :: Spec
 spec = describe "the relay protocol" $ do
@@ -79,7 +79,8 @@ spec = describe "the relay protocol" $ do
           }
         expectedOutDig = Ocd $ outboundClientDigest
           { ocdDefinitions = Map.fromList
-            [ (rootTypeName, OpDefine $ fromJust $ lookupDef rootTypeName $ vsTyDefs baseValuespace)
+            [ (rootTypeName, OpDefine $ fromJust $
+                vsLookupDef rootTypeName baseValuespace)
             , (TypeName foo foo, OpUndefine)
             ]
           , ocdContainerOps = Map.singleton Root $ Map.singleton foo (Nothing, SoAbsent)

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -58,10 +58,8 @@ spec = describe "the relay protocol" $ do
             [ (TypeName foo foo, OpDefine fooDef)
             , (TypeName apiNs [segq|root|], OpDefine extendedRootDef)
             ]
-          -- FIXME: Should only get changed type assignments
           , ocdTypeAssignments = Map.insert
-            [pathq|/foo|] (TypeName foo foo, Cannot)
-            (fmap (,Cannot) $ fst $ vsTyAssns baseValuespace)
+            [pathq|/foo|] (TypeName foo foo, Cannot) mempty
           , ocdContainerOps = Map.singleton Root $ Map.singleton foo (Nothing, SoPresentAfter (Just apiNs))
           }
         test = do

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -15,8 +15,6 @@ import qualified Data.Map as Map
 import Data.Word
 import Data.Maybe (fromJust)
 
-import qualified Data.Map.Mos as Mos
-
 import Clapi.TH
 import Clapi.Protocol (waitThenRevOnly, sendFwd, runEffect, (<<->))
 import Clapi.Relay (relay)
@@ -24,16 +22,15 @@ import Clapi.Tree (treeInsert, RoseTree(RtConstData))
 import Clapi.Types.AssocList (alEmpty, alSingleton, alFromList)
 import Clapi.Types.Base (InterpolationLimit(..))
 import Clapi.Types.Definitions
-  (Definition(..), structDef, tupleDef, Liberty(..))
+  (structDef, tupleDef, Liberty(..))
 import Clapi.Types.Digests
-  ( DefOp(..), DataChange(..), TrpDigest(..), trpDigest, FrpErrorDigest(..)
+  ( DefOp(..), DataChange(..), TrpDigest(..), trpDigest
   , InboundDigest(..), InboundClientDigest(..), OutboundDigest(..), OutboundClientDigest(..)
   , outboundClientDigest, TrprDigest(..))
 import Clapi.Types.SequenceOps (SequenceOp(..))
 import Clapi.Types.Messages (ErrorIndex(..))
 import Clapi.Types.Path (pattern Root, TypeName(..), pattern (:/))
 import Clapi.Types.Tree (ttWord32, unbounded)
-import Clapi.Types.UniqList (ulEmpty, ulSingle)
 import Clapi.Types.Wire (WireValue(..))
 import Clapi.Valuespace
   ( baseValuespace, unsafeValidateVs, apiNs, Valuespace(..)

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -31,7 +31,7 @@ import Clapi.Types
   , TrpDigest(..), DefOp(..), DataChange(..), TypeName(..))
 import qualified Clapi.Types.Path as Path
 import Clapi.Types.Path (Path(..), pattern (:/), pattern Root, Seg)
-import Clapi.Valuespace (Valuespace(..), validateTree, baseValuespace, processToRelayProviderDigest, apiNs)
+import Clapi.Valuespace (Valuespace(..), validateVs, baseValuespace, processToRelayProviderDigest, apiNs)
 import Clapi.Tree (treePaths)
 import Clapi.Types.SequenceOps (SequenceOp(..))
 import Clapi.Tree (RoseTree(RtEmpty))
@@ -102,8 +102,14 @@ refSeg = [segq|ref|]
 spec :: Spec
 spec = do
   describe "Validation" $ do
-    it "baseValuespace valid" $ validateTree baseValuespace
-      `shouldBe` Right baseValuespace
+    it "baseValuespace valid" $
+      let
+        allTainted = Map.fromList $ fmap (,Nothing) $ treePaths Root $
+          vsTree baseValuespace
+        validated = either (error . show) snd $
+          validateVs allTainted baseValuespace
+      in
+        validated `shouldBe` baseValuespace
     it "rechecks on data changes" $
       let
         d = TrpDigest apiNs mempty

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -23,23 +23,29 @@ import Control.Monad.Fail (MonadFail)
 
 import qualified Data.Map.Mos as Mos
 import Clapi.TH
-import Clapi.Types.AssocList (alFromMap, AssocList, mkAssocList, alSingleton, alEmpty, alFromList, alInsert)
+import Clapi.Types.AssocList
+  ( alFromMap, AssocList, mkAssocList, alSingleton, alEmpty, alFromList
+  , alInsert)
 import Clapi.Types
   ( InterpolationLimit(ILUninterpolated), Interpolation(..), WireValue(..)
   , TreeType(..) , TreeConcreteType(..), OfMetaType, Liberty(..)
   , tupleDef, structDef, arrayDef, ErrorIndex(..)
-  , toWireValues, valuesToDef, defDispatch, metaType, Definition(..), StructDefinition(strDefTypes)
+  , toWireValues, valuesToDef, defDispatch, metaType, Definition(..)
+  , StructDefinition(strDefTypes)
   , TrpDigest(..), DefOp(..), DataChange(..), TypeName(..))
 import qualified Clapi.Types.Path as Path
 import Clapi.Types.Path (Path(..), pattern (:/), pattern Root, Seg)
-import Clapi.Valuespace (Valuespace(..), validateVs, baseValuespace, processToRelayProviderDigest, apiNs)
+import Clapi.Valuespace
+  ( Valuespace(..), validateVs, baseValuespace, processToRelayProviderDigest
+  , apiNs)
 import Clapi.Tree (treePaths, updateTreeWithDigest)
 import Clapi.Types.SequenceOps (SequenceOp(..))
 import Clapi.Tree (RoseTree(RtEmpty))
 
 vsProviderErrorsOn :: Valuespace -> TrpDigest -> [Path] -> Expectation
 vsProviderErrorsOn vs d ps = case (processToRelayProviderDigest d vs) of
-    Left errMap -> errMap `shouldSatisfy` (\em -> Set.fromList (PathError <$> ps) == Map.keysSet em)
+    Left errMap -> errMap `shouldSatisfy`
+      (\em -> Set.fromList (PathError <$> ps) == Map.keysSet em)
     Right _ -> fail "Did not get expected errors"
 
 validVersionTypeChange :: Valuespace -> TrpDigest
@@ -48,7 +54,8 @@ validVersionTypeChange vs =
     svd = tupleDef
       "Stringy" (alSingleton [segq|vstr|] $ TtConc $ TcString "pear")
       ILUninterpolated
-    rootDef = redefApiRoot (alInsert [segq|version|] $ TypeName apiNs [segq|stringVersion|]) vs
+    rootDef = redefApiRoot
+      (alInsert [segq|version|] $ TypeName apiNs [segq|stringVersion|]) vs
   in TrpDigest
     apiNs
     (Map.fromList
@@ -64,7 +71,9 @@ vsAppliesCleanly :: MonadFail m => TrpDigest -> Valuespace -> m Valuespace
 vsAppliesCleanly d vs = either (fail . show) (return . snd) $
   processToRelayProviderDigest d vs
 
-redefApiRoot :: (AssocList Seg TypeName -> AssocList Seg TypeName) -> Valuespace -> Definition
+redefApiRoot
+  :: (AssocList Seg TypeName -> AssocList Seg TypeName) -> Valuespace
+  -> Definition
 redefApiRoot f vs = structDef "Frigged by test" $ (, Cannot) <$> f currentKids
   where
     currentKids = fst <$> (grabDefTypes $ grabApi $ grabApi $ vsTyDefs vs)
@@ -91,7 +100,8 @@ vsWithXRef =
   let
     newNodeDef = tupleDef
       "for test"
-      (alSingleton [segq|daRef|] $ TtConc $ TcRef $ TypeName [segq|api|] [segq|version|])
+      (alSingleton [segq|daRef|] $ TtConc $ TcRef $
+        TypeName [segq|api|] [segq|version|])
       ILUninterpolated
     newVal = ConstChange Nothing [WireValue $ Path.toText [pathq|/api/version|]]
   in extendedVs newNodeDef refSeg newVal
@@ -127,8 +137,8 @@ spec = do
             (alSingleton [segq|versionString|] $ TtConc $ TcString "apple")
             ILUninterpolated
           d = TrpDigest
-            apiNs (Map.singleton [segq|version|] $ OpDefine newDef) alEmpty mempty
-            mempty
+            apiNs (Map.singleton [segq|version|] $ OpDefine newDef)
+            alEmpty mempty mempty
       in vsProviderErrorsOn baseValuespace d [[pathq|/api/version|]]
     it "should only re-validate data that has been marked as invalid" $
       let
@@ -153,36 +163,47 @@ spec = do
       -- Change the type of the instance referenced in a cross reference
       vs <- vsWithXRef
       vsProviderErrorsOn vs (validVersionTypeChange vs) [Root :/ apiNs :/ refSeg]
-    it "xref old references do not error" $ do
-      vs <- vsWithXRef
-      -- Add another version
-      let v2s = [segq|v2|]
-      let v2ApiDef = redefApiRoot (alInsert v2s $ TypeName apiNs [segq|version|]) vs
-      let v2Val = alSingleton (Root :/ v2s) $ ConstChange Nothing [WireValue @Word32 1, WireValue @Word32 2, WireValue @Int32 3]
-      vs' <- vsAppliesCleanly (TrpDigest apiNs (Map.singleton apiNs $ OpDefine v2ApiDef) v2Val mempty mempty) vs
-      -- Update the ref to point at new version
-      vs'' <- vsAppliesCleanly
-        (TrpDigest apiNs mempty
-          (alSingleton (Root :/ refSeg)
-           $ ConstChange Nothing [WireValue $ Path.toText [pathq|/api/v2|]])
-          mempty mempty)
-        vs'
-      (vsAppliesCleanly (validVersionTypeChange vs'') vs'' :: Either String Valuespace) `shouldSatisfy` isRight
+    it "xref old references do not error" $
+      let
+        v2s = [segq|v2|]
+        v2Val = alSingleton (Root :/ v2s) $ ConstChange Nothing
+          [WireValue @Word32 1, WireValue @Word32 2, WireValue @Int32 3]
+      in do
+        vs <- vsWithXRef
+        -- Add another version node:
+        let v2ApiDef = redefApiRoot
+              (alInsert v2s $ TypeName apiNs [segq|version|]) vs
+        vs' <- vsAppliesCleanly
+          (TrpDigest apiNs (Map.singleton apiNs $ OpDefine v2ApiDef)
+            v2Val mempty mempty)
+          vs
+        -- Update the ref to point at new version:
+        vs'' <- vsAppliesCleanly
+          (TrpDigest apiNs mempty
+            (alSingleton (Root :/ refSeg)
+             $ ConstChange Nothing [WireValue $ Path.toText [pathq|/api/v2|]])
+            mempty mempty)
+          vs'
+        (vsAppliesCleanly (validVersionTypeChange vs'') vs''
+          :: Either String Valuespace) `shouldSatisfy` isRight
     it "Array" $
       let
         ars = [segq|arr|]
         vaDef = arrayDef "for test" (TypeName apiNs [segq|version|]) Cannot
-        rootDef = redefApiRoot (alInsert ars $ TypeName apiNs ars) baseValuespace
+        rootDef = redefApiRoot (alInsert ars $ TypeName apiNs ars)
+          baseValuespace
         emptyArrayD = TrpDigest
           apiNs
           (Map.fromList [(ars, OpDefine vaDef), (apiNs, OpDefine rootDef)])
           alEmpty
-          (Map.singleton Root $ Map.singleton ars $ (Nothing, SoPresentAfter Nothing))
+          (Map.singleton Root $ Map.singleton ars $
+            (Nothing, SoPresentAfter Nothing))
           mempty
         badChild = TrpDigest
           apiNs
           mempty
-          (alSingleton [pathq|/arr/bad|] $ ConstChange Nothing [WireValue ("boo" :: Text)])
+          (alSingleton [pathq|/arr/bad|] $
+            ConstChange Nothing [WireValue ("boo" :: Text)])
           mempty
           mempty
       in do


### PR DESCRIPTION
Notable fiddling required around cross references adds a hefty complexity and line count to validation. The tests (incl. newly added ones) are useful in checking we didn't stuff up, as it's now super-easy to miss things. Notably, whereas `Valuespace`s were always ok to pass around before, we currently do a bunch of stuff where we don't update their internal cachy stuff until we validate, so asking questions at the wrong time is  Bad Thing(TM) that we don't eliminate with the type checker.