### PR TITLE
Test that we check the presence of all struct children

### DIFF
--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -216,3 +216,13 @@ spec = do
         vs <- vsAppliesCleanly emptyArrayD baseValuespace
         vsProviderErrorsOn vs badChild [[pathq|/api/arr/bad|]]
         (vsAppliesCleanly goodChild vs :: Either String Valuespace) `shouldSatisfy` isRight
+    it "Errors on struct with missing child" $
+      let
+        rootDef = redefApiRoot (alInsert [segq|unfilled|] $ TypeName apiNs [segq|version|]) baseValuespace
+        missingChild = TrpDigest
+          apiNs
+          (Map.singleton apiNs $ OpDefine rootDef)
+          alEmpty
+          mempty
+          mempty
+      in vsProviderErrorsOn baseValuespace missingChild [[pathq|/api|]]


### PR DESCRIPTION
Whilst it has already been fixed, the addition of the test resolves #79.