### PR TITLE
Display name

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -51,7 +51,8 @@ main =
   where
     onDraining = putStrLn "Stopped accepting new connections, waiting for existing clients to disconnect..."
     onTerminated = putStrLn "Forcibly quit"
-    perClientProto addr = (addr, serialiser <<-> digester <<-> attributor "someone")
+    perClientProto addr =
+      ("SomeOne", addr, serialiser <<-> digester <<-> attributor "someone")
     totalProto = shower "total"
       <<-> relayApiProto internalAddr
       <<-> shower "nt"

--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -64,7 +64,7 @@ nstProtocol_ :: (Monad m, Ord i) => StateT (NstState i) (NstProtocol m i) ()
 nstProtocol_ = forever $ liftedWaitThen fwd rev
   where
     sendFwd' i d = lift $ sendFwd (Originator i, d)
-    fwd (ClientConnect _) = return ()
+    fwd (ClientConnect _ _) = return ()
     fwd (ClientData i trd) =
       case trd of
         Trpd d -> claimNamespace i d

--- a/src/Clapi/PerClientProto.hs
+++ b/src/Clapi/PerClientProto.hs
@@ -10,7 +10,7 @@ import Data.ByteString (ByteString)
 import Clapi.Protocol (Protocol, sendFwd, ProtocolF(..), Directed(..))
 
 data ClientEvent ident a
-    = ClientConnect ident
+    = ClientConnect String ident
     | ClientDisconnect ident
     | ClientData ident a
     deriving (Show, Eq,Functor)
@@ -26,14 +26,15 @@ seIdent (ServerDisconnect i) = i
 
 liftToPerClientEvent ::
     Monad m
-    => i
+    => String
+    -> i
     -> Protocol ByteString a ByteString b m ()
     -> Protocol
          ByteString (ClientEvent i a)
          ByteString (ServerEvent i b)
          m ()
-liftToPerClientEvent i proto = do
-    sendFwd $ ClientConnect i
+liftToPerClientEvent displayName i proto = do
+    sendFwd $ ClientConnect displayName i
     inner proto
   where
     inner p = FreeT $ go <$> runFreeT p

--- a/src/Clapi/RelayApi.hs
+++ b/src/Clapi/RelayApi.hs
@@ -84,7 +84,7 @@ relayApiProto selfAddr =
     steadyState timingMap ownerMap = waitThen fwd rev
       where
         fwd ce = case ce of
-          ClientConnect cAddr ->
+          ClientConnect displayName cAddr ->
             let
               cSeg = pathNameFor cAddr
               timingMap' = Map.insert cSeg tdZero timingMap

--- a/src/Clapi/Server.hs
+++ b/src/Clapi/Server.hs
@@ -23,8 +23,6 @@ import Clapi.Protocol (Protocol, runProtocolIO)
 import Clapi.PerClientProto
   (ClientEvent(..), ServerEvent(..), liftToPerClientEvent, seIdent)
 
-data User = Alice | Bob | Charlie deriving (Eq, Ord, Show)
-
 swallowExc :: a -> E.SomeException -> a
 swallowExc = const
 

--- a/src/Clapi/Server.hs
+++ b/src/Clapi/Server.hs
@@ -74,26 +74,26 @@ instance Show (Q.InChan a) where
     show _ = "<InChan>"
 
 _handlePerClient ::
-    i ->
+    String -> i ->
     Protocol B.ByteString a B.ByteString b IO () ->
     ((ServerEvent i b -> IO ()) -> IO (ClientEvent i a -> IO ())) ->
     NS.Socket ->
     IO ()
-_handlePerClient i proto toMainChan sock = do
+_handlePerClient displayName i proto toMainChan sock = do
     (clientChanIn, clientChanOut) <- Q.newChan
     mainChanIn <- toMainChan $ Q.writeChan clientChanIn
     runProtocolIO
         (NSB.recv sock 4096) mainChanIn
         (NSB.sendAll sock) (Q.readChan clientChanOut)
-        (liftToPerClientEvent i proto)
+        (liftToPerClientEvent displayName i proto)
 
 neverDoAnything :: IO a
 neverDoAnything = forever $ threadDelay maxBound
 
 protocolServer
   :: (Ord i)
-  => NS.Socket -> (NS.SockAddr
-  -> (i, Protocol B.ByteString a B.ByteString b IO ()))
+  => NS.Socket
+  -> (NS.SockAddr -> (String, i, Protocol B.ByteString a B.ByteString b IO ()))
   -> Protocol
         (ClientEvent i a) Void
         (ServerEvent i b) Void
@@ -116,6 +116,6 @@ protocolServer listenSock getClientProto mainProto onShutdown = do
     rmReturnPath clientMap i = modifyMVar_ clientMap (return . Map.delete i)
     clientP mainI clientMap _as = serve' listenSock (clientHandler clientMap mainI) onShutdown
     clientHandler clientMap mainI (sock, addr) = do
-        let (i, cp) = getClientProto addr
-        _handlePerClient i cp (addReturnPath clientMap mainI i) sock
+        let (dn, i, cp) = getClientProto addr
+        _handlePerClient dn i cp (addReturnPath clientMap mainI i) sock
         rmReturnPath clientMap i

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -11,7 +11,7 @@ module Clapi.Valuespace
   ( Valuespace, vsTree, vsTyDefs
   , baseValuespace
   , vsLookupDef, valuespaceGet, getLiberty
-  , apiNs, rootTypeName, apiTypeName
+  , apiNs, rootTypeName, apiTypeName, dnSeg
   , processToRelayProviderDigest, processToRelayClientDigest
   , validateVs, unsafeValidateVs
   , vsRelinquish, ValidationErr(..)
@@ -62,7 +62,7 @@ import Clapi.Types.Messages (ErrorIndex(..))
 import Clapi.Types.Path
   (Seg, Path, pattern (:/), pattern Root, pattern (:</), TypeName(..))
 import qualified Clapi.Types.Path as Path
-import Clapi.Types.Tree (TreeType(..), ttWord32, ttInt32, unbounded)
+import Clapi.Types.Tree (TreeType(..), ttWord32, ttInt32, unbounded, ttString)
 import Clapi.Validator (validate, extractTypeAssertion)
 import qualified Clapi.Types.Dkmap as Dkmap
 
@@ -113,6 +113,14 @@ versionDef = TupleDefinition "The version of CLAPI" (unsafeMkAssocList
   , ([segq|revision|], ttInt32 unbounded)
   ]) ILUninterpolated
 
+dnSeg :: Seg
+dnSeg = [segq|display_name|]
+
+displayNameDef :: TupleDefinition
+displayNameDef = TupleDefinition
+  "A human-readable name for a struct or array element"
+  (alSingleton [segq|name|] $ ttString "") ILUninterpolated
+
 -- | Fully revalidates the given Valuespace and throws an error if there are any
 --   validation issues.
 unsafeValidateVs :: Valuespace -> Valuespace
@@ -132,6 +140,7 @@ baseValuespace = unsafeValidateVs $ Valuespace baseTree baseDefs baseTas mempty
     baseDefs = Map.singleton apiNs $ Map.fromList
       [ (apiNs, StructDef apiDef)
       , (vseg, TupleDef versionDef)
+      , (dnSeg, TupleDef displayNameDef)
       ]
     baseTas = Mos.dependenciesFromMap $ Map.singleton Root rootTypeName
 

--- a/test/ServerSpec.hs
+++ b/test/ServerSpec.hs
@@ -195,4 +195,4 @@ echo = forever $ waitThen boing undefined
     boing (ClientData addr a) = sendRev (ServerData addr a)
     boing _ = return ()
 
-getCat addr = (addr, cat)
+getCat addr = ("For Test", addr, cat)


### PR DESCRIPTION
This lays the foundation for specifying the display name of entries in structs and arrays by formalism (rather than as a fundamental part of the API). We define a `display_name` type in the core `api` namespace for the purpose, and we use it in the relay API to publish a pretty name (which we currently make up) for the client. We do not, currently allow clients to change their own names.