### PR TITLE
Proto-post

### DIFF
--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -248,8 +248,6 @@ subResponse (OutboundClientDigest cOps postDefs defs tas dd errs) =
     (pathsInError, postTypesInError, typesInError) =
         foldl collectError mempty $ Map.keys errs
     collectError (pie, ptie, tie) ei = case ei of
-        -- FIXME: err index can't differentiate between POST types and normal
-        -- types.
         PathError p -> (Set.insert p pie, ptie, tie)
         PostTypeError t -> (pie, Set.insert t ptie, tie)
         TypeError t -> (pie, ptie, Set.insert t tie)

--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -325,7 +325,7 @@ frpdsByNamespace (OutboundProviderDigest contOps dd) =
     (_, ddByNs) = nestAlByKey Path.splitHead dd
     -- FIXME: whacking the global stuff to everybody isn't quite right - we need
     -- to know who originated the opd?
-    -- FIXME: this will need to have some POST data in it at some poitn!
+    -- FIXME: this will need to have some POST data in it at some point!
     posts = mempty
     f ns contOps' dd' = FrpDigest ns posts  dd' (contOps' <> rootCOps)
   in

--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -52,13 +52,14 @@ type NstProtocol m i = Protocol
 data NstState i
   = NstState
   { nstOwners :: Map Seg i
+  , nstPostTypeRegistrations :: Mos i TypeName
   , nstTypeRegistrations :: Mos i TypeName
   , nstDataRegistrations :: Mos i Path
   } deriving Show
 
 
 nstProtocol :: (Monad m, Ord i) => NstProtocol m i ()
-nstProtocol = evalStateT nstProtocol_ $ NstState mempty mempty mempty
+nstProtocol = evalStateT nstProtocol_ $ NstState mempty mempty mempty mempty
 
 nstProtocol_ :: (Monad m, Ord i) => StateT (NstState i) (NstProtocol m i) ()
 nstProtocol_ = forever $ liftedWaitThen fwd rev
@@ -92,7 +93,7 @@ nstProtocol_ = forever $ liftedWaitThen fwd rev
         >> (lift $ sendRev $ Right $ ServerDisconnect i) >> handleDisconnect i
 
 nonClaim :: TrpDigest -> Bool
-nonClaim (TrpDigest _ _ dd cops _) = dd == alEmpty && null cops
+nonClaim trpd = trpdData trpd == alEmpty && null (trpdContainerOps trpd)
 
 updateOwners
   :: Monad m => Map Seg i ->  StateT (NstState i) (NstProtocol m i) ()
@@ -186,23 +187,30 @@ toInboundClientDigest i trcd =
     isSub OpSubscribe = True
     isSub OpUnsubscribe = False
     (dSubs, dUnsubs) = mapPair Map.keysSet $ Map.partition isSub $ trcdDataSubs trcd
+    (ptSubs, ptUnsubs) = mapPair Map.keysSet $ Map.partition isSub $ trcdPostTypeSubs trcd
     (tSubs, tUnsubs) = mapPair Map.keysSet $ Map.partition isSub $ trcdTypeSubs trcd
   in do
     nsts <- get
     put nsts{
       nstDataRegistrations = Mos.difference
         (nstDataRegistrations nsts) (Map.singleton i dUnsubs),
+      nstPostTypeRegistrations = Mos.difference
+        (nstPostTypeRegistrations nsts) (Map.singleton i ptUnsubs),
       nstTypeRegistrations = Mos.difference
         (nstTypeRegistrations nsts) (Map.singleton i tUnsubs)}
     let icd = InboundClientDigest
           (Set.difference dSubs $
             Map.findWithDefault mempty i $ nstDataRegistrations nsts)
+          (Set.difference ptSubs $
+            Map.findWithDefault mempty i $ nstPostTypeRegistrations nsts)
           (Set.difference tSubs $
             Map.findWithDefault mempty i $ nstTypeRegistrations nsts)
           (trcdContainerOps trcd)
           (trcdData trcd)
     let frcd = frcdEmpty
-          { frcdTypeUnsubs = Set.intersection tUnsubs $
+          { frcdPostTypeUnsubs = Set.intersection ptUnsubs $
+              Map.findWithDefault mempty i $ nstPostTypeRegistrations nsts
+          , frcdTypeUnsubs = Set.intersection tUnsubs $
               Map.findWithDefault mempty i $ nstTypeRegistrations nsts
           , frcdDataUnsubs = Set.intersection dUnsubs $
             Map.findWithDefault mempty i $ nstDataRegistrations nsts}
@@ -223,39 +231,56 @@ handleDisconnect i = do
 registerSubs
   :: (Ord i, Monad m)
   => i -> OutboundClientInitialisationDigest -> StateT (NstState i) m ()
-registerSubs i (OutboundClientDigest cas defs _tas dd _errs) = modify go
+registerSubs i (OutboundClientDigest cas postDefs defs _tas dd _errs) =
+    modify go
   where
     newDRegsForI = Set.union (Map.keysSet cas) (alKeysSet dd)
-    go (NstState owners tRegs dRegs) = NstState owners
+    go (NstState owners ptRegs tRegs dRegs) = NstState owners
+      (Map.insertWith (<>) i (Map.keysSet postDefs) ptRegs)
       (Map.insertWith (<>) i (Map.keysSet defs) tRegs)
       (Map.insertWith (<>) i newDRegsForI dRegs)
 
 subResponse :: OutboundClientInitialisationDigest -> FrcDigest
-subResponse (OutboundClientDigest cOps defs tas dd errs) =
-    FrcDigest typesInError pathsInError defs tas dd cOps errs
+subResponse (OutboundClientDigest cOps postDefs defs tas dd errs) =
+    FrcDigest postTypesInError typesInError pathsInError postDefs defs tas dd
+    cOps errs
   where
-    (pathsInError, typesInError) =
+    (pathsInError, postTypesInError, typesInError) =
         foldl collectError mempty $ Map.keys errs
-    collectError (pie, tie) ei = case ei of
-        PathError p -> (Set.insert p pie, tie)
-        TypeError t -> (pie, Set.insert t tie)
-        _ -> (pie, tie)
+    collectError (pie, ptie, tie) ei = case ei of
+        -- FIXME: err index can't differentiate between POST types and normal
+        -- types.
+        PathError p -> (Set.insert p pie, ptie, tie)
+        PostTypeError t -> (pie, Set.insert t ptie, tie)
+        TypeError t -> (pie, ptie, Set.insert t tie)
+        _ -> (pie, ptie, tie)
 
 unsubDeleted
   :: (Monad m, Ord i) => OutboundClientDigest
   -> StateT (NstState i) m
-       (Mos i TypeName, Mos i TypeName, Mos i Path, Mos i Path)
+       ( Mos i TypeName, Mos i TypeName
+       , Mos i TypeName, Mos i TypeName
+       , Mos i Path, Mos i Path)
 unsubDeleted d = do
     nsts <- get
+    let (ptUnsubs, ptRemainingSubs) = Mos.partition
+          (`Set.member` allUndefPTys) $ nstPostTypeRegistrations nsts
     let (tUnsubs, tRemainingSubs) = Mos.partition
           (`Set.member` allUndefTys) $ nstTypeRegistrations nsts
     let (dUnsubs, dRemainingSubs) = Mos.partition
           (`Path.isChildOfAny` allDeletePaths) $ nstDataRegistrations nsts
     put $ nsts
       { nstDataRegistrations = dRemainingSubs
-      , nstTypeRegistrations = tRemainingSubs}
-    return (tUnsubs, tRemainingSubs, dUnsubs, dRemainingSubs)
+      , nstPostTypeRegistrations = ptRemainingSubs
+      , nstTypeRegistrations = tRemainingSubs
+      }
+    return
+      ( ptUnsubs, tUnsubs
+      , ptRemainingSubs, tRemainingSubs
+      , dUnsubs, dRemainingSubs
+      )
   where
+    allUndefPTys = Map.keysSet $ Map.filter isUndefTy $ ocdPostDefs d
     allUndefTys = Map.keysSet $ Map.filter isUndefTy $ ocdDefinitions d
     isUndefTy defOp = case defOp of
       OpUndefine -> True
@@ -269,11 +294,15 @@ unsubDeleted d = do
 broadcastClientDigest
   :: (Ord i, Monad m)
   => OutboundClientDigest
-  -> (Mos i TypeName, Mos i TypeName, Mos i Path, Mos i Path)
+  -> ( Mos i TypeName, Mos i TypeName
+     , Mos i TypeName, Mos i TypeName
+     , Mos i Path, Mos i Path)
   -> NstProtocol m i ()
-broadcastClientDigest d (tUnsubs, tRemSubs, dUnsubs, dRemSubs) = do
-    let fromRelayClientDigests = Map.filter (not . frcdNull) $ zipMaps4
-          (produceFromRelayClientDigest d) dUnsubs tUnsubs dRemSubs tRemSubs
+broadcastClientDigest d
+  (ptUnsubs, tUnsubs, ptRemSubs, tRemSubs, dUnsubs, dRemSubs) = do
+    let fromRelayClientDigests = Map.filter (not . frcdNull) $ zipMaps6
+          (produceFromRelayClientDigest d) dUnsubs ptUnsubs tUnsubs dRemSubs
+          ptRemSubs tRemSubs
     void $ sequence $ Map.mapWithKey sendRevWithI fromRelayClientDigests
   where
     sendRevWithI i frcd = sendRev $ Right $ ServerData i $ Frcd frcd
@@ -298,16 +327,20 @@ frpdsByNamespace (OutboundProviderDigest contOps dd) =
     (_, ddByNs) = nestAlByKey Path.splitHead dd
     -- FIXME: whacking the global stuff to everybody isn't quite right - we need
     -- to know who originated the opd?
-    f ns contOps' dd' = FrpDigest ns dd' (contOps' <> rootCOps)
+    -- FIXME: this will need to have some POST data in it at some poitn!
+    posts = mempty
+    f ns contOps' dd' = FrpDigest ns posts  dd' (contOps' <> rootCOps)
   in
     zipMapsWithKey mempty alEmpty f casByNs ddByNs
 
 produceFromRelayClientDigest
-  :: OutboundClientDigest -> Set Path -> Set TypeName
-  -> Set Path -> Set TypeName -> FrcDigest
+  :: OutboundClientDigest -> Set Path -> Set TypeName -> Set TypeName
+  -> Set Path -> Set TypeName -> Set TypeName -> FrcDigest
 produceFromRelayClientDigest
-  (OutboundClientDigest cOps defs tas dd errs) pUsubs tUsubs ps tns = FrcDigest
-    tUsubs pUsubs
+  (OutboundClientDigest cOps postDefs defs tas dd errs) pUsubs ptUnsubs tUsubs
+  ps ptns tns = FrcDigest
+    ptUnsubs tUsubs pUsubs
+    (Map.restrictKeys postDefs ptns)
     (Map.restrictKeys defs tns)
     (Map.restrictKeys tas ps)
     (alFilterKey (`Set.member` ps) dd)
@@ -318,6 +351,7 @@ produceFromRelayClientDigest
       GlobalError -> True
       PathError p -> p `Set.member` ps
       TimePointError p _ -> p `Set.member` ps
+      PostTypeError tn -> tn `Set.member` ptns
       TypeError tn -> tn `Set.member` tns
 
 liftedWaitThen ::
@@ -350,6 +384,15 @@ zipMaps4
   -> Map k e
 zipMaps4 f ma mb mc md = zipMaps (\(a, b) (c, d) -> f a b c d)
   (zipMaps (,) ma mb) (zipMaps (,) mc md)
+
+zipMaps6
+  :: (Ord k, Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f)
+  => (a -> b -> c -> d -> e -> f -> g) -> Map k a -> Map k b -> Map k c
+  -> Map k d -> Map k e -> Map k f -> Map k g
+zipMaps6 fun ma mb mc md me mf =
+  zipMaps (\(a, (b, c)) (d, (e, f)) -> fun a b c d e f)
+  (zipMaps (,) ma (zipMaps (,) mb mc))
+  (zipMaps (,) md (zipMaps (,) me mf))
 
 nestMapsByKey
   :: (Ord k, Ord k0, Ord k1)

--- a/src/Clapi/Relay.hs
+++ b/src/Clapi/Relay.hs
@@ -201,7 +201,8 @@ relay vs = waitThenFwdOnly fwd
           relay vs
 
 -- FIXME: Worst case implementation
-vsMinimiseDefinitions :: Map TypeName DefOp -> Valuespace -> Map TypeName DefOp
+vsMinimiseDefinitions
+  :: Map TypeName (DefOp def) -> Valuespace -> Map TypeName (DefOp def)
 vsMinimiseDefinitions defs _ = defs
 
 -- FIXME: Worst case implementation

--- a/src/Clapi/RelayApi.hs
+++ b/src/Clapi/RelayApi.hs
@@ -45,6 +45,7 @@ relayApiProto selfAddr =
   where
     publishRelayApi = sendFwd $ ClientData selfAddr $ Trpd $ TrpDigest
       rns
+      mempty
       (Map.fromList $ fmap OpDefine <$>
         [ ([segq|build|], tupleDef "builddoc"
              (alSingleton [segq|commit_hash|] $ TtString "banana")
@@ -134,7 +135,7 @@ relayApiProto selfAddr =
               (Map.singleton cSeg (Nothing, SoAbsent)) cops
             steadyState timingMap' ownerMap'
         pubUpdate dd co = sendFwd $ ClientData selfAddr $ Trpd $ TrpDigest
-          rns mempty dd co mempty
+          rns mempty mempty dd co mempty
         rev (Left ownerAddrs) = do
           let ownerMap' = pathNameFor <$> ownerAddrs
           if elem selfAddr $ Map.elems ownerAddrs
@@ -183,6 +184,6 @@ relayApiProto selfAddr =
         -- This function trusts that the valuespace has completely validated the
         -- actions the client can perform (i.e. can only change the name of a
         -- client)
-        handleApiRequest (FrpDigest ns dd cops) =
+        handleApiRequest (FrpDigest ns posts dd cops) =
           sendFwd $ ClientData selfAddr $ Trpd $
-          TrpDigest ns mempty dd cops mempty
+          TrpDigest ns mempty mempty dd cops mempty

--- a/src/Clapi/Serialisation/Base.hs
+++ b/src/Clapi/Serialisation/Base.hs
@@ -6,6 +6,8 @@ module Clapi.Serialisation.Base where
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
 import Control.Monad (liftM2)
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Functor.Identity
 
 import Data.Word
@@ -99,6 +101,10 @@ listParser dec = do
 instance (Encodable a, Ord a, Show a) => Encodable (UniqList a) where
   builder = builder . unUniqList
   parser = parser >>= mkUniqList
+
+instance (Ord k, Encodable k, Encodable v) => Encodable (Map k v) where
+  builder = builder . Map.toList
+  parser = Map.fromList <$> parser
 
 (<<>>) :: (Monad m) => m Builder -> m Builder -> m Builder
 (<<>>) = liftM2 (<>)

--- a/src/Clapi/Serialisation/Definitions.hs
+++ b/src/Clapi/Serialisation/Definitions.hs
@@ -10,7 +10,7 @@ import Clapi.TaggedData (TaggedData, taggedData)
 import Clapi.TextSerialisation (ttToText, ttFromText)
 import Clapi.TH (btq)
 import Clapi.Types.Definitions
-  ( Liberty(..), MetaType(..), metaType
+  ( Liberty(..), Required(..), MetaType(..), metaType
   , TupleDefinition(..), StructDefinition(..), ArrayDefinition(..)
   , Definition(..), defDispatch)
 import Clapi.Types.Tree (TreeType)
@@ -26,6 +26,17 @@ libertyTaggedData = taggedData toTag id
 instance Encodable Liberty where
   builder = tdTaggedBuilder libertyTaggedData $ const $ return mempty
   parser = tdTaggedParser libertyTaggedData return
+
+requiredTaggedData :: TaggedData Required Required
+requiredTaggedData = taggedData toTag id
+  where
+    toTag r = case r of
+      Required -> [btq|r|]
+      Optional -> [btq|o|]
+
+instance Encodable Required where
+  builder = tdTaggedBuilder requiredTaggedData $ const $ return mempty
+  parser = tdTaggedParser requiredTaggedData return
 
 -- FIXME: do we want to serialise the type to text first?!
 instance Encodable TreeType where

--- a/src/Clapi/Serialisation/Definitions.hs
+++ b/src/Clapi/Serialisation/Definitions.hs
@@ -12,7 +12,7 @@ import Clapi.TH (btq)
 import Clapi.Types.Definitions
   ( Liberty(..), Required(..), MetaType(..), metaType
   , TupleDefinition(..), StructDefinition(..), ArrayDefinition(..)
-  , Definition(..), defDispatch)
+  , Definition(..), defDispatch, PostDefinition(..))
 import Clapi.Types.Tree (TreeType)
 
 libertyTaggedData :: TaggedData Liberty Liberty
@@ -74,3 +74,7 @@ instance Encodable Definition where
     Tuple -> TupleDef <$> parser
     Struct -> StructDef <$> parser
     Array -> ArrayDef <$> parser
+
+instance Encodable PostDefinition where
+  builder (PostDefinition doc args) = builder doc <<>> builder args
+  parser = PostDefinition <$> parser <*> parser

--- a/src/Clapi/Serialisation/Messages.hs
+++ b/src/Clapi/Serialisation/Messages.hs
@@ -86,20 +86,27 @@ instance (Encodable ident, Encodable def)
 
 data SubMsgType
   = SubMsgTSub
+  | SubMsgTPostTypeSub
   | SubMsgTTypeSub
   | SubMsgTUnsub
-  | SubMsgTTypeUnsub deriving (Enum, Bounded)
+  | SubMsgTPostTypeUnsub
+  | SubMsgTTypeUnsub
+  deriving (Enum, Bounded)
 
 subMsgTaggedData :: TaggedData SubMsgType SubMessage
 subMsgTaggedData = taggedData typeToTag msgToType
   where
-    typeToTag (SubMsgTSub) = [btq|s|]
-    typeToTag (SubMsgTTypeSub) = [btq|S|]
-    typeToTag (SubMsgTUnsub) = [btq|u|]
-    typeToTag (SubMsgTTypeUnsub) = [btq|U|]
+    typeToTag (SubMsgTSub) = [btq|S|]
+    typeToTag (SubMsgTPostTypeSub) = [btq|P|]
+    typeToTag (SubMsgTTypeSub) = [btq|T|]
+    typeToTag (SubMsgTUnsub) = [btq|s|]
+    typeToTag (SubMsgTPostTypeUnsub) = [btq|p|]
+    typeToTag (SubMsgTTypeUnsub) = [btq|t|]
     msgToType (MsgSubscribe _) = SubMsgTSub
+    msgToType (MsgPostTypeSubscribe _) = SubMsgTPostTypeSub
     msgToType (MsgTypeSubscribe _) = SubMsgTTypeSub
     msgToType (MsgUnsubscribe _) = SubMsgTUnsub
+    msgToType (MsgPostTypeUnsubscribe _) = SubMsgTPostTypeUnsub
     msgToType (MsgTypeUnsubscribe _) = SubMsgTTypeUnsub
 
 instance Encodable SubMessage where
@@ -108,10 +115,14 @@ instance Encodable SubMessage where
         MsgUnsubscribe p -> builder p
         MsgTypeSubscribe t -> builder t
         MsgTypeUnsubscribe t -> builder t
+        MsgPostTypeSubscribe t -> builder t
+        MsgPostTypeUnsubscribe t -> builder t
     parser = tdTaggedParser subMsgTaggedData $ \e -> case e of
         (SubMsgTSub) -> MsgSubscribe <$> parser
+        (SubMsgTPostTypeSub) -> MsgPostTypeSubscribe <$> parser
         (SubMsgTTypeSub) -> MsgTypeSubscribe <$> parser
         (SubMsgTUnsub) -> MsgUnsubscribe <$> parser
+        (SubMsgTPostTypeUnsub) -> MsgPostTypeUnsubscribe <$> parser
         (SubMsgTTypeUnsub) -> MsgTypeUnsubscribe <$> parser
 
 instance Encodable TypeMessage where

--- a/src/Clapi/Serialisation/Messages.hs
+++ b/src/Clapi/Serialisation/Messages.hs
@@ -129,6 +129,10 @@ instance Encodable TypeMessage where
     builder (MsgAssignType p tn l) = builder p <<>> builder tn <<>> builder l
     parser = MsgAssignType <$> parser <*> parser <*> parser
 
+instance Encodable PostMessage where
+    builder (MsgPost p ph args) = builder p <<>> builder ph <<>> builder args
+    parser = MsgPost <$> parser <*> parser <*> parser
+
 data DataUpdateMsgType
   = DUMTConstSet
   | DUMTSet

--- a/src/Clapi/Serialisation/Messages.hs
+++ b/src/Clapi/Serialisation/Messages.hs
@@ -216,19 +216,19 @@ trBundleTaggedData = taggedData typeToTag bundleToType
 
 instance Encodable ToRelayBundle where
     builder = tdTaggedBuilder trBundleTaggedData $ \bund -> case bund of
-      Trpb (ToRelayProviderBundle ns errs defs dat contMsgs) ->
-        builder ns <<>> builder errs <<>> builder defs <<>> builder dat
-        <<>> builder contMsgs
+      Trpb (ToRelayProviderBundle ns errs postDefs defs dat contMsgs) ->
+        builder ns <<>> builder errs <<>> builder postDefs <<>> builder defs
+        <<>> builder dat <<>> builder contMsgs
       Trpr (ToRelayProviderRelinquish ns) -> builder ns
-      Trcb (ToRelayClientBundle subs dat contMsgs) ->
-        builder subs <<>> builder dat <<>> builder contMsgs
+      Trcb (ToRelayClientBundle subs posts dat contMsgs) ->
+        builder subs <<>> builder posts <<>> builder dat <<>> builder contMsgs
     parser = tdTaggedParser trBundleTaggedData $ \ty -> case ty of
       TrbtProvider -> Trpb <$>
         (ToRelayProviderBundle <$> parser <*> parser <*> parser <*> parser
-        <*> parser)
+        <*> parser <*> parser)
       TrbtProviderRelinquish -> Trpr . ToRelayProviderRelinquish <$> parser
       TrbtClient -> Trcb <$>
-        (ToRelayClientBundle <$> parser <*> parser <*> parser)
+        (ToRelayClientBundle <$> parser <*> parser <*> parser <*> parser)
 
 data FrBundleType
   = FrbtProvider | FrbtProviderError | FrbtClient deriving (Enum, Bounded)
@@ -247,17 +247,20 @@ frBundleTaggedData = taggedData typeToTag bundleToType
 
 instance Encodable FromRelayBundle where
     builder = tdTaggedBuilder frBundleTaggedData $ \bund -> case bund of
-      Frpb (FromRelayProviderBundle ns dat contMsgs) ->
-        builder ns <<>> builder dat <<>> builder contMsgs
+      Frpb (FromRelayProviderBundle ns posts dat contMsgs) ->
+        builder ns <<>> builder posts <<>> builder dat <<>> builder contMsgs
       Frpeb (FromRelayProviderErrorBundle errs) -> builder errs
-      Frcb (FromRelayClientBundle tyUns datUns errs defs tas dat contMsgs) ->
-        builder tyUns <<>> builder datUns <<>> builder errs <<>> builder defs
+      Frcb (
+          FromRelayClientBundle pTyUns tyUns datUns errs postDefs defs tas dat
+          contMsgs) ->
+        builder pTyUns <<>> builder tyUns <<>> builder datUns
+        <<>> builder errs <<>> builder postDefs <<>> builder defs
         <<>> builder tas <<>> builder dat <<>> builder contMsgs
     parser = tdTaggedParser frBundleTaggedData $ \ty -> case ty of
       FrbtProvider -> Frpb <$>
-        (FromRelayProviderBundle <$> parser <*> parser <*> parser)
+        (FromRelayProviderBundle <$> parser <*> parser <*> parser <*> parser)
       FrbtProviderError ->
         Frpeb . FromRelayProviderErrorBundle <$> parser
       FrbtClient -> Frcb <$>
         (FromRelayClientBundle <$> parser <*> parser <*>  parser <*> parser
-        <*> parser <*> parser <*> parser)
+        <*> parser <*> parser <*> parser <*> parser <*> parser)

--- a/src/Clapi/Serialisation/Messages.hs
+++ b/src/Clapi/Serialisation/Messages.hs
@@ -24,6 +24,7 @@ data ErrIdxType
   = EitGlobal
   | EitPath
   | EitTimePoint
+  | EitPostTypeName
   | EitTypeName
   deriving (Enum, Bounded)
 
@@ -34,11 +35,13 @@ errIdxTaggedData = taggedData typeToTag eiToType
       EitGlobal -> [btq|g|]
       EitPath -> [btq|p|]
       EitTimePoint -> [btq|t|]
+      EitPostTypeName -> [btq|c|]  -- "create"
       EitTypeName -> [btq|n|]
     eiToType ei = case ei of
       GlobalError -> EitGlobal
       PathError _ -> EitPath
       TimePointError _ _ -> EitTimePoint
+      PostTypeError _ -> EitPostTypeName
       TypeError _ -> EitTypeName
 
 instance Encodable a => Encodable (ErrorIndex a) where
@@ -46,11 +49,13 @@ instance Encodable a => Encodable (ErrorIndex a) where
     GlobalError -> return mempty
     PathError p -> builder p
     TimePointError p tpid -> builder p <<>> builder tpid
+    PostTypeError tn -> builder tn
     TypeError tn -> builder tn
   parser = tdTaggedParser errIdxTaggedData $ \eit -> case eit of
     EitGlobal -> return GlobalError
     EitPath -> PathError <$> parser
     EitTimePoint -> TimePointError <$> parser <*> parser
+    EitPostTypeName -> PostTypeError <$> parser
     EitTypeName -> TypeError <$> parser
 
 

--- a/src/Clapi/Serialisation/Messages.hs
+++ b/src/Clapi/Serialisation/Messages.hs
@@ -60,7 +60,7 @@ instance Encodable a => Encodable (MsgError a) where
 
 data DefMsgType = DefMsgTDef | DefMsgTUndef deriving (Enum, Bounded)
 
-defMsgTaggedData :: TaggedData DefMsgType (DefMessage a)
+defMsgTaggedData :: TaggedData DefMsgType (DefMessage a def)
 defMsgTaggedData = taggedData typeToTag msgToType
   where
     typeToTag ty = case ty of
@@ -70,7 +70,8 @@ defMsgTaggedData = taggedData typeToTag msgToType
       MsgDefine _ _ -> DefMsgTDef
       MsgUndefine _ -> DefMsgTUndef
 
-instance Encodable a => Encodable (DefMessage a) where
+instance (Encodable ident, Encodable def)
+  => Encodable (DefMessage ident def) where
     builder = tdTaggedBuilder defMsgTaggedData $ \msg -> case msg of
       MsgDefine tn def -> builder tn <<>> builder def
       MsgUndefine tn -> builder tn

--- a/src/Clapi/Types/Definitions.hs
+++ b/src/Clapi/Types/Definitions.hs
@@ -5,21 +5,15 @@
 module Clapi.Types.Definitions where
 
 import Prelude hiding (fail)
-import Control.Monad (join)
 import Control.Monad.Fail (MonadFail(..))
 import Data.Text (Text)
-import Data.Word
 
 import Data.Maybe.Clapi (note)
 
-import Clapi.TextSerialisation (ttToText, ttFromText)
-import Clapi.Types.AssocList (AssocList, unAssocList, alFromZip)
+import Clapi.Types.AssocList (AssocList, unAssocList)
 import Clapi.Types.Base (InterpolationLimit(..))
-import Clapi.Types.Path
-  (Seg, mkSeg, unSeg, TypeName, typeNameToText, typeNameFromText)
-import Clapi.Types.Tree (TreeType)
-import Clapi.Types.Wire (WireValue(..), (<|$|>), (<|*|>))
-import Clapi.Util (strictZip, fmtStrictZipError, safeToEnum)
+import Clapi.Types.Path (Seg, TypeName)
+import Clapi.Types.Tree (TreeType(..))
 
 data Liberty = Cannot | May | Must deriving (Show, Eq, Enum, Bounded)
 
@@ -27,8 +21,6 @@ data MetaType = Tuple | Struct | Array deriving (Show, Eq, Enum, Bounded)
 
 class OfMetaType metaType where
   metaType :: metaType -> MetaType
-  toWireValues :: metaType -> [WireValue]
-  fromWireValues :: MonadFail m => [WireValue] -> m metaType
   childTypeFor :: Seg -> metaType -> Maybe TypeName
   childLibertyFor :: MonadFail m => metaType -> Seg -> m Liberty
 
@@ -40,30 +32,6 @@ data TupleDefinition = TupleDefinition
 
 instance OfMetaType TupleDefinition where
   metaType _ = Tuple
-  toWireValues (TupleDefinition d tys il) =
-    let
-      (names, treeTypes) = unzip $ unAssocList tys
-    in
-      [ WireValue d
-      , WireValue $ unSeg <$> names
-      , WireValue $ ttToText <$> treeTypes
-      , WireValue @Word8 $ fromIntegral $ fromEnum il
-      ]
-
-  fromWireValues [txt, txts0, txts1, w8] =
-      join $ mkDef <|$|> txt <|*|> txts0 <|*|> txts1 <|*|> w8
-    where
-      mkDef
-        :: MonadFail m => Text -> [Text] -> [Text] -> Word8
-        -> m TupleDefinition
-      mkDef d ns ts il = do
-        names <- mapM mkSeg ns
-        types <- mapM ttFromText ts
-        al <- alFromZip names types
-        interp <- safeToEnum $ fromIntegral il
-        return $ TupleDefinition d al interp
-  fromWireValues _ = fail "Wrong number of arguments for tuple def"
-
   childTypeFor _ _ = Nothing
   childLibertyFor _ _ = fail "Tuples have no children"
 
@@ -74,32 +42,6 @@ data StructDefinition = StructDefinition
 
 instance OfMetaType StructDefinition where
   metaType _ = Struct
-  toWireValues (StructDefinition d tys) =
-    let
-      (names, tys') = unzip $ unAssocList tys
-      (tps, libs) = unzip tys'
-    in
-      [ WireValue d
-      , WireValue $ unSeg <$> names
-      , WireValue $ typeNameToText <$> tps
-      , WireValue @[Word8] $ fromIntegral . fromEnum <$> libs
-      ]
-
-  fromWireValues [txt, txts0, txts1, w8s] =
-      join $ mkDef <|$|> txt <|*|> txts0 <|*|> txts1 <|*|> w8s
-    where
-      mkDef
-        :: MonadFail m => Text -> [Text] -> [Text] -> [Word8]
-        -> m StructDefinition
-      mkDef d ns tns ls = do
-        names <- mapM mkSeg ns
-        typeNames <- mapM typeNameFromText tns
-        clibs <- mapM (safeToEnum . fromIntegral) ls
-        StructDefinition d <$>
-          (fmtStrictZipError "type names" "liberties"
-             (strictZip typeNames clibs) >>= alFromZip names)
-  fromWireValues _ = fail "Wrong number of arguments for struct def"
-
   childTypeFor seg (StructDefinition _ tyInfo) =
     fst <$> lookup seg (unAssocList tyInfo)
   childLibertyFor (StructDefinition _ tyInfo) seg = note "No such child" $
@@ -113,20 +55,6 @@ data ArrayDefinition = ArrayDefinition
 
 instance OfMetaType ArrayDefinition where
   metaType _ = Array
-  toWireValues (ArrayDefinition d ct cl) =
-    [ WireValue d
-    , WireValue $ typeNameToText ct
-    , WireValue @Word8 $ fromIntegral $ fromEnum cl
-    ]
-
-  fromWireValues [doc, ty, liberty] =
-      join $ mkDef <|$|> doc <|*|> ty <|*|> liberty
-    where
-      mkDef :: MonadFail m => Text -> Text -> Word8 -> m ArrayDefinition
-      mkDef d tn l = ArrayDefinition d
-        <$> typeNameFromText tn <*> safeToEnum (fromIntegral l)
-  fromWireValues _ = fail "Wrong number of arguments for array def"
-
   childTypeFor _ (ArrayDefinition _ tp _) = Just tp
   childLibertyFor (ArrayDefinition _ _ l) _ = return l
 
@@ -150,8 +78,3 @@ defDispatch :: (forall a. OfMetaType a => a -> r) -> Definition -> r
 defDispatch f (TupleDef d) = f d
 defDispatch f (StructDef d) = f d
 defDispatch f (ArrayDef d) = f d
-
-valuesToDef :: MonadFail m => MetaType -> [WireValue] -> m Definition
-valuesToDef Tuple wvs = TupleDef <$> fromWireValues wvs
-valuesToDef Struct wvs = StructDef <$> fromWireValues wvs
-valuesToDef Array wvs = ArrayDef <$> fromWireValues wvs

--- a/src/Clapi/Types/Definitions.hs
+++ b/src/Clapi/Types/Definitions.hs
@@ -16,6 +16,7 @@ import Clapi.Types.Path (Seg, TypeName)
 import Clapi.Types.Tree (TreeType(..))
 
 data Liberty = Cannot | May | Must deriving (Show, Eq, Enum, Bounded)
+data Required = Required | Optional deriving (Show, Eq, Enum, Bounded)
 
 data MetaType = Tuple | Struct | Array deriving (Show, Eq, Enum, Bounded)
 

--- a/src/Clapi/Types/Definitions.hs
+++ b/src/Clapi/Types/Definitions.hs
@@ -6,6 +6,7 @@ module Clapi.Types.Definitions where
 
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
+import Data.Map (Map)
 import Data.Text (Text)
 
 import Data.Maybe.Clapi (note)
@@ -24,6 +25,11 @@ class OfMetaType metaType where
   metaType :: metaType -> MetaType
   childTypeFor :: Seg -> metaType -> Maybe TypeName
   childLibertyFor :: MonadFail m => metaType -> Seg -> m Liberty
+
+data PostDefinition = PostDefinition
+  { postDefDoc :: Text
+  , postDefArgs :: Map Seg (TreeType, Required)
+  } deriving (Show, Eq)
 
 data TupleDefinition = TupleDefinition
   { tupDefDoc :: Text

--- a/src/Clapi/Types/Definitions.hs
+++ b/src/Clapi/Types/Definitions.hs
@@ -26,6 +26,8 @@ class OfMetaType metaType where
 
 data TupleDefinition = TupleDefinition
   { tupDefDoc :: Text
+  -- FIXME: this should eventually boil down to a single TreeType (NB remove
+  -- names too and just write more docstring) now that we have pairs:
   , tupDefTypes :: AssocList Seg TreeType
   , tupDefInterpLimit :: InterpolationLimit
   } deriving (Show, Eq)

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -3,8 +3,8 @@
 
 module Clapi.Types.Digests where
 
+import Data.Foldable (foldl')
 import Data.Maybe (fromJust)
-import Data.Either (partitionEithers)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
@@ -16,7 +16,7 @@ import Data.Word (Word32)
 import Clapi.Types.AssocList
   (AssocList, alNull, alEmpty, alFromList, alFmapWithKey, alValues, alKeysSet)
 import Clapi.Types.Base (Attributee, Time, Interpolation)
-import Clapi.Types.Definitions (Definition, Liberty)
+import Clapi.Types.Definitions (Definition, Liberty, PostDefinition)
 import Clapi.Types.Messages
 import Clapi.Types.Path (Seg, Path, TypeName(..), pattern (:</), pattern (:/))
 import Clapi.Types.SequenceOps (SequenceOp(..), isSoAbsent)
@@ -44,8 +44,12 @@ type DataDigest = AssocList Path DataChange
 
 type ContainerOps = Map Path (Map Seg (Maybe Attributee, SequenceOp Seg))
 
+data PostOp
+  = OpPost {opPath :: Path, opArgs :: Map Seg WireValue} deriving (Show, Eq)
+
 data TrpDigest = TrpDigest
   { trpdNamespace :: Seg
+  , trpdPostDefs :: Map Seg (DefOp PostDefinition)
   , trpdDefinitions :: Map Seg (DefOp Definition)
   , trpdData :: DataDigest
   , trpdContainerOps :: ContainerOps
@@ -53,41 +57,51 @@ data TrpDigest = TrpDigest
   } deriving (Show, Eq)
 
 trpDigest :: Seg -> TrpDigest
-trpDigest ns = TrpDigest ns mempty alEmpty mempty mempty
+trpDigest ns = TrpDigest ns mempty mempty alEmpty mempty mempty
 
 trpdRemovedPaths :: TrpDigest -> [Path]
-trpdRemovedPaths (TrpDigest ns _ _ cOps _) = (ns :</) <$> Map.foldlWithKey f [] cOps
+trpdRemovedPaths trpd =
+    (trpdNamespace trpd :</) <$> Map.foldlWithKey f [] (trpdContainerOps trpd)
   where
     f acc p segMap = acc ++
       (fmap (p :/) $ Map.keys $ Map.filter isSoAbsent $ fmap snd segMap)
 
 trpdNull :: TrpDigest -> Bool
-trpdNull (TrpDigest _ns defs dd cops errs) = null defs && alNull dd && null cops && null errs
+trpdNull (TrpDigest _ns postDefs defs dd cops errs) =
+  null postDefs && null defs && alNull dd && null cops && null errs
 
 data FrpDigest = FrpDigest
   { frpdNamespace :: Seg
+  , frpdPosts :: Map Seg PostOp
   , frpdData :: DataDigest
   , frpdContainerOps :: ContainerOps
   } deriving (Show, Eq)
+
+frpDigest :: Seg -> FrpDigest
+frpDigest ns = FrpDigest ns mempty alEmpty mempty
 
 data FrpErrorDigest = FrpErrorDigest
   { frpedErrors :: Map (ErrorIndex TypeName) [Text]
   } deriving (Show, Eq)
 
 data TrcDigest = TrcDigest
-  { trcdTypeSubs :: Map TypeName SubOp
+  { trcdPostTypeSubs :: Map TypeName SubOp
+  , trcdTypeSubs :: Map TypeName SubOp
   , trcdDataSubs :: Map Path SubOp
+  , trcdPosts :: Map Seg PostOp
   , trcdData :: DataDigest
   , trcdContainerOps :: ContainerOps
   } deriving (Show, Eq)
 
 trcdEmpty :: TrcDigest
-trcdEmpty = TrcDigest mempty mempty alEmpty mempty
+trcdEmpty = TrcDigest mempty mempty mempty mempty alEmpty mempty
 
 data FrcDigest = FrcDigest
-  { frcdTypeUnsubs :: Set TypeName
+  { frcdPostTypeUnsubs :: Set TypeName
+  , frcdTypeUnsubs :: Set TypeName
   , frcdDataUnsubs :: Set Path
-  , frcdDefinitions :: Map TypeName DefOp
+  , frcdPostDefs :: Map TypeName (DefOp PostDefinition)
+  , frcdDefinitions :: Map TypeName (DefOp Definition)
   , frcdTypeAssignments :: Map Path (TypeName, Liberty)
   , frcdData :: DataDigest
   , frcdContainerOps :: ContainerOps
@@ -95,7 +109,8 @@ data FrcDigest = FrcDigest
   } deriving (Show, Eq)
 
 frcdEmpty :: FrcDigest
-frcdEmpty = FrcDigest mempty mempty mempty mempty alEmpty mempty mempty
+frcdEmpty = FrcDigest mempty mempty mempty mempty mempty mempty alEmpty mempty
+  mempty
 
 newtype TrprDigest = TrprDigest {trprdNamespace :: Seg} deriving (Show, Eq)
 
@@ -112,10 +127,12 @@ data FrDigest
   deriving (Show, Eq)
 
 trcdNamespaces :: TrcDigest -> Set Seg
-trcdNamespaces (TrcDigest ts ds dd co) =
-    (Set.map tnNamespace $ Map.keysSet ts)
-    <> pathKeyNss (Map.keysSet ds) <> pathKeyNss (alKeysSet dd)
-    <> pathKeyNss (Map.keysSet co)
+trcdNamespaces (TrcDigest pts ts ds posts dd co) =
+    (Set.map tnNamespace $ Map.keysSet pts)
+    <> (Set.map tnNamespace $ Map.keysSet ts)
+    <> pathKeyNss (Map.keysSet ds)
+    <> pathKeyNss (Set.fromList $ Map.elems $ opPath <$> posts)
+    <> pathKeyNss (alKeysSet dd) <> pathKeyNss (Map.keysSet co)
   where
     pathKeyNss = onlyJusts . Set.map pNs
     onlyJusts = Set.map fromJust . Set.delete Nothing
@@ -123,9 +140,9 @@ trcdNamespaces (TrcDigest ts ds dd co) =
     pNs _ = Nothing
 
 frcdNull :: FrcDigest -> Bool
-frcdNull (FrcDigest tyUns datUns defs tas dd cops errs) =
-  null tyUns && null datUns && null defs && null tas && null dd && null cops
-  && null errs
+frcdNull (FrcDigest pTyUns tyUns datUns postDefs defs tas dd cops errs) =
+  null pTyUns && null tyUns && null datUns && null postDefs && null defs
+  && null tas && null dd && null cops && null errs
 
 -- | "Split" because kinda like :: Map k1 a -> Map k2 (Map k3 a)
 splitMap :: (Ord a, Ord b) => [(a, (b, c))] -> Map a (Map b c)
@@ -188,20 +205,26 @@ produceDefMessages = Map.elems . Map.mapWithKey
      OpDefine def -> MsgDefine a def
      OpUndefine -> MsgUndefine a)
 
-digestSubMessages :: [SubMessage] -> (Map TypeName SubOp, Map Path SubOp)
-digestSubMessages msgs =
-  let (tss, dss) = partitionEithers $ fmap procMsg msgs in
-    (Map.fromList tss, Map.fromList dss)
+digestSubMessages
+  :: [SubMessage] -> (Map TypeName SubOp, Map TypeName SubOp, Map Path SubOp)
+digestSubMessages msgs = foldl' procMsg mempty msgs
   where
-    procMsg msg = case msg of
-      MsgSubscribe p -> Right $ (p, OpSubscribe)
-      MsgTypeSubscribe tn -> Left $ (tn, OpSubscribe)
-      MsgUnsubscribe p -> Right $ (p, OpUnsubscribe)
-      MsgTypeUnsubscribe tn -> Left $ (tn, OpUnsubscribe)
+    procMsg (post, ty, dat) msg = case msg of
+      MsgSubscribe p -> (post, ty, Map.insert p OpSubscribe dat)
+      MsgPostTypeSubscribe tn -> (Map.insert tn OpSubscribe post, ty, dat)
+      MsgTypeSubscribe tn -> (post, Map.insert tn OpSubscribe ty, dat)
+      MsgUnsubscribe p -> (post, ty, Map.insert p OpUnsubscribe dat)
+      MsgPostTypeUnsubscribe tn -> (Map.insert tn OpUnsubscribe post, ty, dat)
+      MsgTypeUnsubscribe tn -> (post, Map.insert tn OpUnsubscribe ty, dat)
 
-produceSubMessages :: Map TypeName SubOp -> Map Path SubOp -> [SubMessage]
-produceSubMessages tySubs datSubs = tySubMsgs ++ datSubMsgs
+produceSubMessages
+  :: Map TypeName SubOp -> Map TypeName SubOp -> Map Path SubOp -> [SubMessage]
+produceSubMessages pTySubs tySubs datSubs =
+    pTySubMsgs ++ tySubMsgs ++ datSubMsgs
   where
+    pTySubMsgs = Map.elems $ Map.mapWithKey (\tn op -> case op of
+      OpSubscribe -> MsgPostTypeSubscribe tn
+      OpUnsubscribe -> MsgPostTypeUnsubscribe tn) pTySubs
     tySubMsgs = Map.elems $ Map.mapWithKey (\tn op -> case op of
       OpSubscribe -> MsgTypeSubscribe tn
       OpUnsubscribe -> MsgTypeUnsubscribe tn) tySubs
@@ -228,6 +251,16 @@ produceErrMessages :: Map (ErrorIndex a) [Text] -> [MsgError a]
 produceErrMessages =
   mconcat . Map.elems . Map.mapWithKey (\ei errs -> MsgError ei <$> errs)
 
+digestPostMessages :: [PostMessage] -> Map Seg PostOp
+digestPostMessages = Map.fromList . fmap pmToPo
+  where
+    pmToPo (MsgPost path ph args) = (ph, OpPost path args)
+
+producePostMessages :: Map Seg PostOp -> [PostMessage]
+producePostMessages = fmap (uncurry poToPm) . Map.toList
+  where
+    poToPm ph (OpPost path args) = MsgPost path ph args
+
 digestToRelayBundle :: ToRelayBundle -> TrDigest
 digestToRelayBundle trb = case trb of
     Trpb b -> Trpd $ digestToRelayProviderBundle b
@@ -235,8 +268,10 @@ digestToRelayBundle trb = case trb of
     Trcb b -> Trcd $ digestToRelayClientBundle b
   where
     digestToRelayProviderBundle :: ToRelayProviderBundle -> TrpDigest
-    digestToRelayProviderBundle (ToRelayProviderBundle ns errs defs dat cont) =
+    digestToRelayProviderBundle
+        (ToRelayProviderBundle ns errs postDefs defs dat cont) =
       TrpDigest ns
+        (digestDefMessages postDefs)
         (digestDefMessages defs)
         (digestDataUpdateMessages dat)
         (digestContOpMessages cont)
@@ -247,13 +282,14 @@ digestToRelayBundle trb = case trb of
       TrprDigest ns
 
     digestToRelayClientBundle :: ToRelayClientBundle -> TrcDigest
-    digestToRelayClientBundle (ToRelayClientBundle subs dat cont) =
+    digestToRelayClientBundle (ToRelayClientBundle subs postMsgs dat cont) =
       let
-        (tySubs, datSubs) = digestSubMessages subs
+        (postTySubs, tySubs, datSubs) = digestSubMessages subs
+        postD = digestPostMessages postMsgs
         dd = digestDataUpdateMessages dat
         co = digestContOpMessages cont
       in
-        TrcDigest tySubs datSubs dd co
+        TrcDigest postTySubs tySubs datSubs postD dd co
 
 produceToRelayBundle :: TrDigest -> ToRelayBundle
 produceToRelayBundle trd = case trd of
@@ -261,21 +297,23 @@ produceToRelayBundle trd = case trd of
     Trprd d -> Trpr $ produceToRelayProviderRelinquish d
     Trcd d -> Trcb $ produceToRelayClientBundle d
   where
-    produceToRelayProviderBundle (TrpDigest ns defs dat cops errs) =
+    produceToRelayProviderBundle (TrpDigest ns postDefs defs dat cops errs) =
       ToRelayProviderBundle
-        ns (produceErrMessages errs) (produceDefMessages defs)
+        ns (produceErrMessages errs)
+        (produceDefMessages postDefs) (produceDefMessages defs)
         (produceDataUpdateMessages dat) (produceContOpMessages cops)
 
     produceToRelayProviderRelinquish (TrprDigest ns) =
       ToRelayProviderRelinquish ns
 
-    produceToRelayClientBundle (TrcDigest tySubs datSubs dd co) =
+    produceToRelayClientBundle (TrcDigest pTySubs tySubs datSubs postD dd co) =
       let
-        subs = produceSubMessages tySubs datSubs
+        subs = produceSubMessages pTySubs tySubs datSubs
+        postMsgs = producePostMessages postD
         dat = produceDataUpdateMessages dd
         cont = produceContOpMessages co
       in
-        ToRelayClientBundle subs dat cont
+        ToRelayClientBundle subs postMsgs dat cont
 
 digestFromRelayBundle :: FromRelayBundle -> FrDigest
 digestFromRelayBundle frb = case frb of
@@ -283,21 +321,25 @@ digestFromRelayBundle frb = case frb of
     Frpeb b -> Frped $ digestFromRelayProviderErrorBundle b
     Frcb b -> Frcd $ digestFromRelayClientBundle b
   where
-    digestFromRelayProviderBundle (FromRelayProviderBundle ns dums coms) =
-        FrpDigest ns (digestDataUpdateMessages dums) (digestContOpMessages coms)
+    digestFromRelayProviderBundle (FromRelayProviderBundle ns posts dums coms) =
+        FrpDigest ns (digestPostMessages posts) (digestDataUpdateMessages dums)
+          (digestContOpMessages coms)
 
     digestFromRelayProviderErrorBundle (FromRelayProviderErrorBundle errs) =
         FrpErrorDigest $ digestErrMessages errs
 
-    digestFromRelayClientBundle (FromRelayClientBundle tSubs dSubs errs defs tas dums coms) =
-        FrcDigest
-          (Set.fromList tSubs)
-          (Set.fromList dSubs)
-          (digestDefMessages defs)
-          (digestTypeMessages tas)
-          (digestDataUpdateMessages dums)
-          (digestContOpMessages coms)
-          (digestErrMessages errs)
+    digestFromRelayClientBundle
+        (FromRelayClientBundle ptSubs tSubs dSubs errs postDefs defs tas dums coms) =
+      FrcDigest
+        (Set.fromList ptSubs)
+        (Set.fromList tSubs)
+        (Set.fromList dSubs)
+        (digestDefMessages postDefs)
+        (digestDefMessages defs)
+        (digestTypeMessages tas)
+        (digestDataUpdateMessages dums)
+        (digestContOpMessages coms)
+        (digestErrMessages errs)
 
 produceFromRelayBundle :: FrDigest -> FromRelayBundle
 produceFromRelayBundle frd = case frd of
@@ -306,9 +348,9 @@ produceFromRelayBundle frd = case frd of
     Frcd d -> Frcb $ produceFromRelayClientBundle d
   where
     produceFromRelayProviderBundle :: FrpDigest -> FromRelayProviderBundle
-    produceFromRelayProviderBundle (FrpDigest ns dd co) =
-      FromRelayProviderBundle ns (produceDataUpdateMessages dd)
-      (produceContOpMessages co)
+    produceFromRelayProviderBundle (FrpDigest ns posts dd co) =
+      FromRelayProviderBundle ns (producePostMessages posts)
+      (produceDataUpdateMessages dd) (produceContOpMessages co)
 
     produceFromRelayProviderErrorBundle
       :: FrpErrorDigest -> FromRelayProviderErrorBundle
@@ -316,10 +358,13 @@ produceFromRelayBundle frd = case frd of
       FromRelayProviderErrorBundle $ produceErrMessages errs
 
     produceFromRelayClientBundle :: FrcDigest -> FromRelayClientBundle
-    produceFromRelayClientBundle (FrcDigest tyUns datUns defs tas dd co errs) =
+    produceFromRelayClientBundle
+        (FrcDigest postTyUns tyUns datUns postDefs defs tas dd co errs) =
       FromRelayClientBundle
-        (Set.toList tyUns) (Set.toList datUns) (produceErrMessages errs)
-        (produceDefMessages defs) (produceTypeMessages tas)
+        (Set.toList postTyUns) (Set.toList tyUns) (Set.toList datUns)
+        (produceErrMessages errs)
+        (produceDefMessages postDefs) (produceDefMessages defs)
+        (produceTypeMessages tas)
         (produceDataUpdateMessages dd) (produceContOpMessages co)
 
 -- The following are slightly different (and more internal to the relay), they
@@ -327,10 +372,14 @@ produceFromRelayBundle frd = case frd of
 
 data InboundClientDigest = InboundClientDigest
   { icdGets :: Set Path
+  , icdPostTypeGets :: Set TypeName
   , icdTypeGets :: Set TypeName
   , icdContainerOps :: ContainerOps
   , icdData :: DataDigest
   } deriving (Show, Eq)
+
+inboundClientDigest :: InboundClientDigest
+inboundClientDigest = InboundClientDigest mempty mempty mempty mempty alEmpty
 
 -- -- | This is basically a TrpDigest with the namespace expanded out
 -- data InboundProviderDigest = InboundProviderDigest
@@ -355,18 +404,21 @@ data InboundDigest
 
 data OutboundClientDigest = OutboundClientDigest
   { ocdContainerOps :: ContainerOps
-  , ocdDefinitions :: Map TypeName DefOp
+  , ocdPostDefs :: Map TypeName (DefOp PostDefinition)
+  , ocdDefinitions :: Map TypeName (DefOp Definition)
   , ocdTypeAssignments :: Map Path (TypeName, Liberty)
   , ocdData :: DataDigest
   , ocdErrors :: Map (ErrorIndex TypeName) [Text]
   } deriving (Show, Eq)
 
 outboundClientDigest :: OutboundClientDigest
-outboundClientDigest = OutboundClientDigest mempty mempty mempty alEmpty mempty
+outboundClientDigest = OutboundClientDigest mempty mempty mempty mempty alEmpty
+    mempty
 
 ocdNull :: OutboundClientDigest -> Bool
-ocdNull (OutboundClientDigest cops defs tas dd errs) =
-    null cops && null defs && null tas && alNull dd && null errs
+ocdNull (OutboundClientDigest cops postDefs defs tas dd errs) =
+    null cops && null postDefs && null defs && null tas && alNull dd
+    && null errs
 
 type OutboundClientInitialisationDigest = OutboundClientDigest
 

--- a/src/Clapi/Types/Messages.hs
+++ b/src/Clapi/Types/Messages.hs
@@ -39,9 +39,9 @@ namespaceErrIdx ns ei = case ei of
 data MsgError a
   = MsgError {errIndex :: ErrorIndex a, errMsgTxt :: Text} deriving (Eq, Show)
 
-data DefMessage a
-  = MsgDefine a Definition
-  | MsgUndefine a
+data DefMessage ident def
+  = MsgDefine ident def
+  | MsgUndefine ident
   deriving (Show, Eq)
 
 data SubMessage
@@ -91,7 +91,7 @@ data ContainerUpdateMessage
 data ToRelayProviderBundle = ToRelayProviderBundle
   { trpbNamespace :: Seg
   , trpbErrors :: [MsgError Seg]
-  , trpbDefinitions :: [DefMessage Seg]
+  , trpbDefinitions :: [DefMessage Seg Definition]
   , trpbData :: [DataUpdateMessage]
   , trpbContMsgs :: [ContainerUpdateMessage]
   } deriving (Show, Eq)
@@ -119,7 +119,7 @@ data FromRelayClientBundle = FromRelayClientBundle
   { frcbTypeUnsubs :: [TypeName]
   , frcbDataUnsubs :: [Path]
   , frcbErrors :: [MsgError TypeName]
-  , frcbDefinitions :: [DefMessage TypeName]
+  , frcbDefinitions :: [DefMessage TypeName Definition]
   , frcbTypeAssignments :: [TypeMessage]
   , frcbData :: [DataUpdateMessage]
   , frcbContMsgs :: [ContainerUpdateMessage]

--- a/src/Clapi/Types/Messages.hs
+++ b/src/Clapi/Types/Messages.hs
@@ -47,10 +47,14 @@ data DefMessage ident def
   | MsgUndefine ident
   deriving (Show, Eq)
 
+-- FIXME: might be nicer to break this up into sub and unsub values typed by
+-- what they are subscriptions for:
 data SubMessage
   = MsgSubscribe {subMsgPath :: Path}
+  | MsgPostTypeSubscribe {subMsgTypeName :: TypeName}
   | MsgTypeSubscribe {subMsgTypeName :: TypeName}
   | MsgUnsubscribe {subMsgPath :: Path}
+  | MsgPostTypeUnsubscribe {subMsgTypeName :: TypeName}
   | MsgTypeUnsubscribe {subMsgTypeName :: TypeName}
   deriving (Eq, Show)
 

--- a/src/Clapi/Types/Messages.hs
+++ b/src/Clapi/Types/Messages.hs
@@ -8,7 +8,7 @@ import Data.Text (Text)
 import Data.Word (Word32)
 
 import Clapi.Types.Base (Attributee, Time, Interpolation)
-import Clapi.Types.Definitions (Definition, Liberty)
+import Clapi.Types.Definitions (Definition, Liberty, PostDefinition)
 import Clapi.Types.Path (Seg, Path, TypeName(..), pattern (:</))
 import qualified Clapi.Types.Path as Path
 import Clapi.Types.Wire (WireValue)
@@ -106,6 +106,7 @@ data ContainerUpdateMessage
 data ToRelayProviderBundle = ToRelayProviderBundle
   { trpbNamespace :: Seg
   , trpbErrors :: [MsgError Seg]
+  , trpbPostDefs :: [DefMessage Seg PostDefinition]
   , trpbDefinitions :: [DefMessage Seg Definition]
   , trpbData :: [DataUpdateMessage]
   , trpbContMsgs :: [ContainerUpdateMessage]
@@ -116,6 +117,7 @@ data ToRelayProviderRelinquish
 
 data FromRelayProviderBundle = FromRelayProviderBundle
   { frpbNamespace :: Seg
+  , frpbPosts :: [PostMessage]
   , frpbData :: [DataUpdateMessage]
   , frpbContMsgs :: [ContainerUpdateMessage]
   } deriving (Show, Eq)
@@ -126,14 +128,17 @@ data FromRelayProviderErrorBundle = FromRelayProviderErrorBundle
 
 data ToRelayClientBundle = ToRelayClientBundle
   { trcbSubs :: [SubMessage]
+  , trcbPosts :: [PostMessage]
   , trcbData :: [DataUpdateMessage]
   , trcbContMsgs :: [ContainerUpdateMessage]
   } deriving (Eq, Show)
 
 data FromRelayClientBundle = FromRelayClientBundle
-  { frcbTypeUnsubs :: [TypeName]
+  { frcbPostTypeUnsubs :: [TypeName]
+  , frcbTypeUnsubs :: [TypeName]
   , frcbDataUnsubs :: [Path]
   , frcbErrors :: [MsgError TypeName]
+  , frcbPostDefs :: [DefMessage TypeName PostDefinition]
   , frcbDefinitions :: [DefMessage TypeName Definition]
   , frcbTypeAssignments :: [TypeMessage]
   , frcbData :: [DataUpdateMessage]

--- a/src/Clapi/Types/Messages.hs
+++ b/src/Clapi/Types/Messages.hs
@@ -3,6 +3,7 @@
 
 module Clapi.Types.Messages where
 
+import Data.Map (Map)
 import Data.Text (Text)
 import Data.Word (Word32)
 
@@ -59,6 +60,13 @@ data SubMessage
   deriving (Eq, Show)
 
 data TypeMessage = MsgAssignType Path TypeName Liberty deriving (Show, Eq)
+
+data PostMessage
+  = MsgPost
+  { pMsgPath :: Path
+  , pMsgPlaceholder :: Seg
+  , pMsgArgs :: Map Seg WireValue
+  } deriving (Show, Eq)
 
 data DataUpdateMessage
   = MsgConstSet

--- a/src/Clapi/Types/Messages.hs
+++ b/src/Clapi/Types/Messages.hs
@@ -19,6 +19,7 @@ data ErrorIndex a
   = GlobalError
   | PathError Path
   | TimePointError Path TpId
+  | PostTypeError a
   | TypeError a
   deriving (Show, Eq, Ord)
 
@@ -27,6 +28,7 @@ splitErrIdx ei = case ei of
   GlobalError -> Nothing
   PathError p -> fmap PathError <$> Path.splitHead p
   TimePointError p tpid -> fmap (flip TimePointError tpid) <$> Path.splitHead p
+  PostTypeError (TypeName ns s) -> Just (ns, PostTypeError s)
   TypeError (TypeName ns s) -> Just (ns, TypeError s)
 
 namespaceErrIdx :: Seg -> ErrorIndex Seg -> ErrorIndex TypeName
@@ -34,6 +36,7 @@ namespaceErrIdx ns ei = case ei of
   GlobalError -> GlobalError
   PathError p -> PathError $ ns :</ p
   TimePointError p tpid -> TimePointError (ns :</ p) tpid
+  PostTypeError s -> PostTypeError (TypeName ns s)
   TypeError s -> TypeError $ TypeName ns s
 
 data MsgError a

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -8,9 +8,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 module Clapi.Valuespace
-  ( Valuespace, vsTree, vsTyDefs
+  ( Valuespace, vsTree, vsTyDefs, vsPostDefs
   , baseValuespace
-  , vsLookupDef, valuespaceGet, getLiberty
+  , vsLookupPostDef, vsLookupDef, valuespaceGet, getLiberty
   , apiNs, rootTypeName, apiTypeName, dnSeg
   , processToRelayProviderDigest, processToRelayClientDigest
   , validateVs, unsafeValidateVs
@@ -145,6 +145,14 @@ baseValuespace = unsafeValidateVs $
       , (dnSeg, TupleDef displayNameDef)
       ]
     baseTas = Mos.dependenciesFromMap $ Map.singleton Root rootTypeName
+
+lookupPostDef
+  :: MonadFail m => TypeName -> DefMap PostDefinition -> m PostDefinition
+lookupPostDef (TypeName ns s) defs = note "Missing post def" $
+    Map.lookup ns defs >>= Map.lookup s
+
+vsLookupPostDef :: MonadFail m => TypeName -> Valuespace -> m PostDefinition
+vsLookupPostDef tn vs = lookupPostDef tn $ vsPostDefs vs
 
 lookupDef :: MonadFail m => TypeName -> DefMap Definition -> m Definition
 lookupDef tn@(TypeName ns s) defs = note "Missing def" $

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -53,7 +53,7 @@ import Clapi.Types.AssocList
   , unsafeMkAssocList, alMapKeys, alFmapWithKey, alToMap)
 import Clapi.Types.Definitions
   ( Definition(..), Liberty(..), TupleDefinition(..)
-  , StructDefinition(..), defDispatch, childLibertyFor
+  , StructDefinition(..), PostDefinition(..), defDispatch, childLibertyFor
   , childTypeFor)
 import Clapi.Types.Digests
   ( DefOp(..), isUndef, ContainerOps, DataChange(..), isRemove, DataDigest
@@ -74,6 +74,7 @@ type Xrefs = Map Referee (Map Referer (Maybe (Set TpId)))
 
 data Valuespace = Valuespace
   { vsTree :: RoseTree [WireValue]
+  , vsPostDefs :: DefMap PostDefinition
   , vsTyDefs :: DefMap Definition
   , vsTyAssns :: TypeAssignmentMap
   , vsXrefs :: Xrefs
@@ -130,7 +131,8 @@ unsafeValidateVs vs = either (error . show) snd $ validateVs allTainted vs
       vsTree vs
 
 baseValuespace :: Valuespace
-baseValuespace = unsafeValidateVs $ Valuespace baseTree baseDefs baseTas mempty
+baseValuespace = unsafeValidateVs $
+    Valuespace baseTree mempty baseDefs baseTas mempty
   where
     vseg = [segq|version|]
     version = RtConstData Nothing
@@ -172,7 +174,7 @@ getLiberty path vs = case path of
 valuespaceGet
   :: MonadFail m => Path -> Valuespace
   -> m (Definition, TypeName, Liberty, RoseTreeNode [WireValue])
-valuespaceGet p vs@(Valuespace tree defs tas _) = do
+valuespaceGet p vs@(Valuespace tree _ defs tas _) = do
     rtn <- note "Path not found" $ Tree.treeLookupNode p tree
     tn <- lookupTypeName p tas
     def <- lookupDef tn defs
@@ -358,6 +360,7 @@ processToRelayProviderDigest trpd vs =
     xrefs' = Map.foldlWithKey' (\x r ts -> removeXrefsTps r ts x) (vsXrefs vs) $
       fmap tpRemovals $ alToMap qData
     (undefOps, defOps) = Map.partition isUndef (trpdDefinitions trpd)
+    postDefs' = vsPostDefs vs
     defs' =
       let
         newDefs = odDef <$> defOps
@@ -371,7 +374,7 @@ processToRelayProviderDigest trpd vs =
     unless (null updateErrs) $ Left $ Map.mapKeys PathError updateErrs
     (updatedTypes, vs') <- first (fmap $ fmap $ Text.pack . show) $ validateVs
       (Map.fromSet (const Nothing) redefdPaths <> updatedPaths) $
-      Valuespace tree' defs' tas xrefs'
+      Valuespace tree' postDefs' defs' tas xrefs'
     return (updatedTypes, vs')
 
 validatePath :: Valuespace -> Path -> Maybe (Set TpId) -> Either [ValidationErr] (Either RefTypeClaims (Map TpId RefTypeClaims))
@@ -490,12 +493,13 @@ validateWireValues tts wvs =
 
 -- FIXME: The VS you get back from this can be invalid WRT refs/inter NS types
 vsRelinquish :: Seg -> Valuespace -> Valuespace
-vsRelinquish ns (Valuespace tree defs tas xrefs) =
+vsRelinquish ns (Valuespace tree postDefs defs tas xrefs) =
   let
     nsp = Root :/ ns
   in
     Valuespace
       (Tree.treeDelete nsp tree)
+      (Map.delete ns postDefs)
       (Map.delete ns defs)
       (Mos.filterDeps
        (\p (TypeName ns' _) -> not $ p `Path.isChildOf` nsp || ns == ns') tas)

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -160,8 +160,8 @@ lookupTypeName :: MonadFail m => Path -> TypeAssignmentMap -> m TypeName
 lookupTypeName p = note "Type name not found" . Mos.getDependency p
 
 defForPath :: MonadFail m => Path -> Valuespace -> m Definition
-defForPath p (Valuespace _ defs tas _) =
-  lookupTypeName p tas >>= flip lookupDef defs
+defForPath p vs =
+  lookupTypeName p (vsTyAssns vs) >>= flip lookupDef (vsTyDefs vs)
 
 getLiberty :: MonadFail m => Path -> Valuespace -> m Liberty
 getLiberty path vs = case path of
@@ -270,7 +270,8 @@ validateVs t v = do
       -> Map Path (Maybe (Set TpId)) -> Valuespace
       -> Either (Map (ErrorIndex TypeName) [ValidationErr])
            (Map Path TypeName, TypeClaimsByPath, Valuespace)
-    inner newTas newRefClaims tainted vs@(Valuespace tree _ oldTyAssns _) =
+    inner newTas newRefClaims tainted vs =
+      let tree = vsTree vs; oldTyAssns = vsTyAssns vs in
       case Map.toAscList tainted of
         [] -> return (newTas, newRefClaims, vs)
         ((path, invalidatedTps):_) ->

--- a/test/NamespaceTrackerSpec.hs
+++ b/test/NamespaceTrackerSpec.hs
@@ -24,8 +24,9 @@ import Clapi.Types
 import Clapi.Types.Definitions (tupleDef)
 import Clapi.Types.Digests
   ( OutboundDigest(..), InboundDigest(..)
-  , InboundClientDigest(..), OutboundClientDigest(..), outboundClientDigest
-  , OutboundProviderDigest(..), SubOp(..), DefOp(..))
+  , InboundClientDigest(..), inboundClientDigest
+  , OutboundClientDigest(..), outboundClientDigest
+  , OutboundProviderDigest(..), frpDigest, SubOp(..), DefOp(..))
 import Clapi.Types.Path (Path, Seg, pattern Root, TypeName(..))
 import Clapi.Types.AssocList (alSingleton, alEmpty, alFromList)
 import Clapi.Types.SequenceOps (SequenceOp(..))
@@ -125,11 +126,8 @@ spec = do
         helloDef1 = OpDefine $ tupleDef "Hoyo" alEmpty ILUninterpolated
         fauxRelay = do
             i <- waitThenFwdOnly $ \(i, d) -> do
-                lift (d `shouldBe` Icd (InboundClientDigest
+                lift (d `shouldBe` Icd (inboundClientDigest
                   { icdGets = Set.singleton helloP
-                  , icdTypeGets = mempty
-                  , icdContainerOps = mempty
-                  , icdData = alEmpty
                   }))
                 return i
             sendRev (i, Ocid $ ocdEmpty
@@ -228,10 +226,8 @@ spec = do
             expectRev $ Left $ Map.fromList
               [ (helloS, alice)
               ] -- FIXME: should API be owned?
-            expectRev $ Right $ ServerData alice $ Frpd $ FrpDigest
-              { frpdNamespace = helloS
-              , frpdData = alSingleton Root $ textChange "x"
-              , frpdContainerOps = mempty
+            expectRev $ Right $ ServerData alice $ Frpd (frpDigest helloS)
+              { frpdData = alSingleton Root $ textChange "x"
               }
         fauxRelay = do
             waitThenFwdOnly $ \(i, d) -> sendRev (i, Opd $ OutboundProviderDigest

--- a/test/NamespaceTrackerSpec.hs
+++ b/test/NamespaceTrackerSpec.hs
@@ -49,12 +49,7 @@ helloP :: Path
 helloP = [pathq|/hello|]
 
 ocdEmpty :: OutboundClientDigest
-ocdEmpty = OutboundClientDigest
-  { ocdContainerOps = mempty
-  , ocdDefinitions = mempty
-  , ocdTypeAssignments = mempty
-  , ocdData = alEmpty
-  , ocdErrors = mempty}
+ocdEmpty = outboundClientDigest
 
 -- Collects responses until the identified client disconnects
 collectAllResponsesUntil ::
@@ -137,27 +132,20 @@ spec = do
                   , icdData = alEmpty
                   }))
                 return i
-            sendRev (i, Ocid $ OutboundClientDigest
-              { ocdContainerOps = mempty
-              , ocdDefinitions = Map.singleton helloTn helloDef0
-              , ocdTypeAssignments = mempty
+            sendRev (i, Ocid $ ocdEmpty
+              { ocdDefinitions = Map.singleton helloTn helloDef0
               , ocdData = alSingleton helloP $ textChange "f"
-              , ocdErrors = mempty})
-            sendRev (i, Ocd $ OutboundClientDigest
-              { ocdContainerOps = mempty
-              , ocdDefinitions = mempty
-              , ocdTypeAssignments = mempty
-              , ocdData = alFromList
+              })
+            sendRev (i, Ocd $ ocdEmpty
+              { ocdData = alFromList
                 [ (helloP, textChange "t")
                 , ([pathq|/nowhere|], textChange "banana")
                 ]
-              , ocdErrors = mempty})
-            sendRev (i, Ocd $ OutboundClientDigest
-              { ocdContainerOps = mempty
-              , ocdDefinitions = Map.singleton helloTn helloDef1
-              , ocdTypeAssignments = mempty
+              })
+            sendRev (i, Ocd $ ocdEmpty
+              { ocdDefinitions = Map.singleton helloTn helloDef1
               , ocdData = alSingleton helloP $ textChange "w"
-              , ocdErrors = mempty})
+              })
             waitThenFwdOnly $ const return ()
             relayNoMore
       in runEffect $ forTest <<-> nstProtocol <<-> fauxRelay
@@ -267,12 +255,12 @@ spec = do
               { frcdData = alSingleton helloP $ textChange "a" }
         fauxRelay = do
             waitThenFwdOnly $ \(i, _) ->
-                sendRev (i, Ocid $ outboundClientDigest
+                sendRev (i, Ocid $ ocdEmpty
                   { ocdErrors = Map.singleton (PathError helloP) ["pants"] })
             waitThenFwdOnly $ \(i, _) -> do
-                sendRev (i, Ocid $ outboundClientDigest
+                sendRev (i, Ocid $ ocdEmpty
                   { ocdData = alSingleton helloP $ textChange "i" })
-                sendRev (i, Ocd $ outboundClientDigest
+                sendRev (i, Ocd $ ocdEmpty
                   { ocdData = alSingleton helloP $ textChange "a" })
             relayNoMore
       in runEffect $ forTest <<-> nstProtocol <<-> fauxRelay

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -96,7 +96,7 @@ spec = describe "the relay protocol" $ do
           }
         test = do
           sendFwd ((), Icd $
-            InboundClientDigest (Set.singleton p) mempty mempty alEmpty)
+            InboundClientDigest (Set.singleton p) mempty mempty mempty alEmpty)
           waitThenRevOnly $ lift . (`shouldBe` expectedOutDig) . snd
       in runEffect $ test <<-> relay baseValuespace
     it "should have container ops for implicitly created children" $
@@ -146,8 +146,8 @@ spec = describe "the relay protocol" $ do
     it "should not send empty ocids/opds to client requests" $
       let
         test = do
-            sendFwd (1, Icd $ InboundClientDigest mempty mempty mempty alEmpty)
-            sendFwd (2, Icd $ InboundClientDigest (Set.singleton [pathq|/whatevz|]) mempty mempty alEmpty)
+            sendFwd (1, Icd $ InboundClientDigest mempty mempty mempty mempty alEmpty)
+            sendFwd (2, Icd $ InboundClientDigest (Set.singleton [pathq|/whatevz|]) mempty mempty mempty alEmpty)
             waitThenRevOnly $ lift . (`shouldSatisfy` (== (2 :: Int)) . fst)
       in runEffect $ test <<-> relay baseValuespace
   where

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -53,8 +53,10 @@ instance (Arbitrary ident, Arbitrary def)
 
 instance Arbitrary SubMessage where
   arbitrary = oneof
-      [ MsgTypeSubscribe <$> arbitrary
+      [ MsgPostTypeSubscribe <$> arbitrary
+      , MsgTypeSubscribe <$> arbitrary
       , MsgSubscribe <$> arbitrary
+      , MsgPostTypeUnsubscribe <$> arbitrary
       , MsgTypeUnsubscribe <$> arbitrary
       , MsgUnsubscribe <$> arbitrary]
 
@@ -106,6 +108,7 @@ instance Arbitrary a => Arbitrary (ErrorIndex a) where
     [ return GlobalError
     , PathError <$> arbitrary
     , TimePointError <$> arbitrary <*> arbitrary
+    , PostTypeError <$> arbitrary
     , TypeError <$> arbitrary
     ]
 

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -7,6 +7,7 @@ module SerialisationSpec where
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
 import Data.ByteString (ByteString)
+import qualified Data.Map as Map
 import qualified Data.ByteString as BS
 
 import Test.Hspec
@@ -64,7 +65,8 @@ instance Arbitrary TypeMessage where
   arbitrary = MsgAssignType <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary PostMessage where
-  arbitrary = MsgPost <$> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = MsgPost <$> arbitrary <*> arbitrary <*>
+    (Map.fromList <$> smallListOf arbitrary)
 
 genAttributee :: Gen (Maybe Attributee)
 genAttributee = oneof [return Nothing, Just <$> arbitraryTextNoNull]
@@ -117,32 +119,38 @@ instance Arbitrary a => Arbitrary (MsgError a) where
 
 
 instance Arbitrary ToRelayProviderBundle where
-  arbitrary = ToRelayProviderBundle <$> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = ToRelayProviderBundle
+    <$> arbitrary <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary
   shrink (ToRelayProviderBundle n e pt t d c) =
     [ToRelayProviderBundle n e' pt' t' d' c' |
        (e', pt', t', d', c') <- shrink (e, pt, t, d, c)]
 
 instance Arbitrary FromRelayProviderBundle where
-  arbitrary = FromRelayProviderBundle <$> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary
+  arbitrary = FromRelayProviderBundle <$> arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary
 
 instance Arbitrary ToRelayProviderRelinquish where
   arbitrary = ToRelayProviderRelinquish <$> arbitrary
 
 instance Arbitrary FromRelayProviderErrorBundle where
-  arbitrary = FromRelayProviderErrorBundle <$> arbitrary
+  arbitrary = FromRelayProviderErrorBundle <$> smallListOf arbitrary
 
 instance Arbitrary ToRelayClientBundle where
-  arbitrary = ToRelayClientBundle <$> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary
+  arbitrary = ToRelayClientBundle <$> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary
   shrink (ToRelayClientBundle s p d c) =
     [ToRelayClientBundle s' p' d' c' | (s', p', d', c') <- shrink (s, p, d, c)]
 
 instance Arbitrary FromRelayClientBundle where
-  arbitrary = FromRelayClientBundle <$> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary
+  arbitrary = FromRelayClientBundle <$> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
   shrink (FromRelayClientBundle ptu tu du e postDefs defs tas dd c) =
     [FromRelayClientBundle ptu' tu' du' e' postDefs' defs' tas' dd' c'
     | (ptu', tu', du', e', postDefs', defs', tas', dd', c')

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -19,7 +19,8 @@ import Data.Attoparsec.ByteString (parseOnly, endOfInput)
 import Clapi.Types
   ( Time, Attributee, WireValue
   , Interpolation(..), SubMessage(..), DataUpdateMessage(..), TypeMessage(..)
-  , MsgError(..), TpId, DefMessage(..), ContainerUpdateMessage(..)
+  , PostMessage(..), MsgError(..), TpId, DefMessage(..)
+  , ContainerUpdateMessage(..)
   , ToRelayClientBundle(..), ToRelayProviderBundle(..)
   , FromRelayClientBundle(..), FromRelayProviderBundle(..)
   , FromRelayProviderErrorBundle(..), ToRelayProviderRelinquish(..)
@@ -59,6 +60,9 @@ instance Arbitrary SubMessage where
 
 instance Arbitrary TypeMessage where
   arbitrary = MsgAssignType <$> arbitrary <*> arbitrary <*> arbitrary
+
+instance Arbitrary PostMessage where
+  arbitrary = MsgPost <$> arbitrary <*> arbitrary <*> arbitrary
 
 genAttributee :: Gen (Maybe Attributee)
 genAttributee = oneof [return Nothing, Just <$> arbitraryTextNoNull]

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -115,12 +115,14 @@ instance Arbitrary a => Arbitrary (MsgError a) where
 
 instance Arbitrary ToRelayProviderBundle where
   arbitrary = ToRelayProviderBundle <$> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary
-  shrink (ToRelayProviderBundle n e t d c) =
-    [ToRelayProviderBundle n e' t' d' c' | (e', t', d', c') <- shrink (e, t, d, c)]
+    <*> arbitrary <*> arbitrary <*> arbitrary
+  shrink (ToRelayProviderBundle n e pt t d c) =
+    [ToRelayProviderBundle n e' pt' t' d' c' |
+       (e', pt', t', d', c') <- shrink (e, pt, t, d, c)]
 
 instance Arbitrary FromRelayProviderBundle where
   arbitrary = FromRelayProviderBundle <$> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary
 
 instance Arbitrary ToRelayProviderRelinquish where
   arbitrary = ToRelayProviderRelinquish <$> arbitrary
@@ -130,16 +132,18 @@ instance Arbitrary FromRelayProviderErrorBundle where
 
 instance Arbitrary ToRelayClientBundle where
   arbitrary = ToRelayClientBundle <$> arbitrary <*> arbitrary <*> arbitrary
-  shrink (ToRelayClientBundle s d c) =
-    [ToRelayClientBundle s' d' c' | (s', d', c') <- shrink (s, d, c)]
+    <*> arbitrary
+  shrink (ToRelayClientBundle s p d c) =
+    [ToRelayClientBundle s' p' d' c' | (s', p', d', c') <- shrink (s, p, d, c)]
 
 instance Arbitrary FromRelayClientBundle where
   arbitrary = FromRelayClientBundle <$> arbitrary <*> arbitrary <*> arbitrary
-    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
-  shrink (FromRelayClientBundle tu du e defs tas dd c) =
-    [FromRelayClientBundle tu' du' e' defs' tas' dd' c'
-    | (tu', du', e', defs', tas', dd', c')
-    <- shrink (tu, du, e, defs, tas, dd, c)]
+    <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+    <*> arbitrary
+  shrink (FromRelayClientBundle ptu tu du e postDefs defs tas dd c) =
+    [FromRelayClientBundle ptu' tu' du' e' postDefs' defs' tas' dd' c'
+    | (ptu', tu', du', e', postDefs', defs', tas', dd', c')
+    <- shrink (ptu, tu, du, e, postDefs, defs, tas, dd, c)]
 
 
 instance Arbitrary ToRelayBundle where

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -43,7 +43,8 @@ instance Arbitrary Interpolation where
       , return ILinear
       , IBezier <$> arbitrary <*> arbitrary]
 
-instance Arbitrary a => Arbitrary (DefMessage a) where
+instance (Arbitrary ident, Arbitrary def)
+    => Arbitrary (DefMessage ident def) where
   arbitrary = oneof
     [ MsgDefine <$> arbitrary <*> arbitrary
     , MsgUndefine <$> arbitrary

--- a/test/TypesSpec.hs
+++ b/test/TypesSpec.hs
@@ -29,7 +29,7 @@ import Data.Int (Int32, Int64)
 import Clapi.TextSerialisation (argsOpen, argsClose)
 import Clapi.Types
   ( Time(..), WireValue(..), WireType(..), Wireable, castWireValue, Liberty
-  , InterpolationLimit, Definition(..), StructDefinition(..)
+  , InterpolationLimit, PostDefinition(..), Definition(..), StructDefinition(..)
   , TupleDefinition(..), ArrayDefinition(..), AssocList, alFromMap
   , wireValueWireType, withWtProxy, Required)
 import Clapi.Util (proxyF, proxyF3)
@@ -156,6 +156,9 @@ spec = do
 
 instance (Ord a, Arbitrary a, Arbitrary b) => Arbitrary (AssocList a b) where
   arbitrary = alFromMap <$> arbitrary
+
+instance Arbitrary PostDefinition where
+  arbitrary = PostDefinition <$> arbitrary <*> arbitrary
 
 instance Arbitrary Definition where
     arbitrary =

--- a/test/TypesSpec.hs
+++ b/test/TypesSpec.hs
@@ -31,7 +31,7 @@ import Clapi.Types
   ( Time(..), WireValue(..), WireType(..), Wireable, castWireValue, Liberty
   , InterpolationLimit, Definition(..), StructDefinition(..)
   , TupleDefinition(..), ArrayDefinition(..), AssocList, alFromMap
-  , wireValueWireType, withWtProxy)
+  , wireValueWireType, withWtProxy, Required)
 import Clapi.Util (proxyF, proxyF3)
 
 import Clapi.Types.Tree (TreeType(..), Bounds, bounds, ttEnum)
@@ -65,6 +65,9 @@ instance Arbitrary TypeName where
   arbitrary = TypeName <$> arbitrary <*> arbitrary
 
 instance Arbitrary Liberty where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary Required where
     arbitrary = arbitraryBoundedEnum
 
 instance Arbitrary InterpolationLimit where

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -30,7 +30,7 @@ import Clapi.Types
   ( InterpolationLimit(ILUninterpolated), Interpolation(..), WireValue(..)
   , TreeType(..) , OfMetaType, Liberty(..)
   , tupleDef, structDef, arrayDef, ErrorIndex(..)
-  , toWireValues, valuesToDef, defDispatch, metaType, Definition(..)
+  , defDispatch, metaType, Definition(..)
   , StructDefinition(strDefTypes)
   , TrpDigest(..), DefOp(..), DataChange(..), TypeName(..))
 import qualified Clapi.Types.Path as Path

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -61,6 +61,7 @@ validVersionTypeChange vs =
       (alInsert [segq|version|] $ TypeName apiNs [segq|stringVersion|]) vs
   in TrpDigest
     apiNs
+    mempty
     (Map.fromList
       [ ([segq|stringVersion|], OpDefine svd)
       , (apiNs, OpDefine rootDef)
@@ -90,6 +91,7 @@ extendedVs def s dc =
     rootDef = redefApiRoot (alInsert s $ TypeName apiNs s) baseValuespace
     d = TrpDigest
       apiNs
+      mempty
       (Map.fromList
         [ (s, OpDefine def)
         , (apiNs, OpDefine rootDef)])
@@ -115,6 +117,7 @@ refSeg = [segq|ref|]
 emptyArrayD :: Seg -> Valuespace -> TrpDigest
 emptyArrayD s vs = TrpDigest
     apiNs
+    mempty
     (Map.fromList [(s, OpDefine vaDef), (apiNs, OpDefine rootDef)])
     alEmpty
     mempty
@@ -138,7 +141,7 @@ spec = do
         validated `shouldBe` baseValuespace
     it "rechecks on data changes" $
       let
-        d = TrpDigest apiNs mempty
+        d = TrpDigest apiNs mempty mempty
           (alSingleton [pathq|/version|] $
            ConstChange Nothing [WireValue @Text "wrong"])
           mempty mempty
@@ -152,13 +155,14 @@ spec = do
             (alSingleton [segq|versionString|] $ TtString "apple")
             ILUninterpolated
           d = TrpDigest
-            apiNs (Map.singleton [segq|version|] $ OpDefine newDef)
+            apiNs mempty (Map.singleton [segq|version|] $ OpDefine newDef)
             alEmpty mempty mempty
       in vsProviderErrorsOn baseValuespace d [[pathq|/api/version|]]
     it "rechecks on container ops" $
       let
         d = TrpDigest
             apiNs
+            mempty
             mempty
             alEmpty
             (Map.singleton Root $ Map.singleton [segq|version|] (Nothing, SoAbsent))
@@ -198,12 +202,12 @@ spec = do
         let v2ApiDef = redefApiRoot
               (alInsert v2s $ TypeName apiNs [segq|version|]) vs
         vs' <- vsAppliesCleanly
-          (TrpDigest apiNs (Map.singleton apiNs $ OpDefine v2ApiDef)
+          (TrpDigest apiNs mempty (Map.singleton apiNs $ OpDefine v2ApiDef)
             v2Val mempty mempty)
           vs
         -- Update the ref to point at new version:
         vs'' <- vsAppliesCleanly
-          (TrpDigest apiNs mempty
+          (TrpDigest apiNs mempty mempty
             (alSingleton (Root :/ refSeg)
              $ ConstChange Nothing [WireValue $ Path.toText [pathq|/api/v2|]])
             mempty mempty)
@@ -216,6 +220,7 @@ spec = do
         badChild = TrpDigest
           apiNs
           mempty
+          mempty
           (alSingleton [pathq|/arr/bad|] $
             ConstChange Nothing [WireValue ("boo" :: Text)])
           mempty
@@ -223,12 +228,14 @@ spec = do
         goodChild = TrpDigest
           apiNs
           mempty
+          mempty
           (alSingleton [pathq|/arr/mehearties|] $
             ConstChange Nothing [WireValue @Word32 3, WireValue @Word32 4, WireValue @Int32 3])
           mempty
           mempty
         removeGoodChild = TrpDigest
           apiNs
+          mempty
           mempty
           alEmpty
           (Map.singleton [pathq|/arr|] $ Map.singleton [segq|mehearties|] (Nothing, SoAbsent))
@@ -244,6 +251,7 @@ spec = do
         rootDef = redefApiRoot (alInsert [segq|unfilled|] $ TypeName apiNs [segq|version|]) baseValuespace
         missingChild = TrpDigest
           apiNs
+          mempty
           (Map.singleton apiNs $ OpDefine rootDef)
           alEmpty
           mempty
@@ -255,6 +263,7 @@ spec = do
         fooRootDef = arrayDef "frd" (TypeName apiNs [segq|version|]) Cannot
         claimFoo = TrpDigest
           fs
+          mempty
           (Map.singleton fs $ OpDefine fooRootDef)
           alEmpty
           mempty


### PR DESCRIPTION
This is a kinda vertical slice through doing the "POST" stuff where we can add new items to arrays using a flat collection of named wire values. We add the ability to talk about posting how we want in messages (and digests), and some of the existing structures (`NamespaceTracker`, `Valuespace`, `Relay`) support their normal behaviours but with the new post types included. (This is a first approximation that just makes the typechecker happy and uses copy-paste heavy guessing for the implementation!).

On the subject of tagged/phantom'd `TypeName` - I avoided starting with constraining the type because I was worried it was going to make some of the structures more awkward. There were some places where I think we could really benefit from it, because of @foolswood's concern that we might accidentally cross `TypeName`s over somewhere. I might investigate retro-fitting the tagging now that we have a full cut that at least passes the existing tests. 