### PR TITLE
Namespace clients

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.Text as T
 import Crypto.Hash.SHA256 (hash)
 import qualified Data.ByteString.Base16 as B16
+import System.IO (hPutStrLn, stderr)
 
 import Clapi.Server (protocolServer, withListen)
 import Clapi.SerialisationProtocol (serialiser, digester)
@@ -49,8 +50,9 @@ main =
     withListen onDraining onTerminated HostAny "1234" $ \(lsock, _) ->
         protocolServer lsock perClientProto totalProto (return ())
   where
-    onDraining = putStrLn "Stopped accepting new connections, waiting for existing clients to disconnect..."
-    onTerminated = putStrLn "Forcibly quit"
+    onDraining = hPutStrLn stderr
+      "Stopped accepting new connections, waiting for existing clients to disconnect..."
+    onTerminated = hPutStrLn stderr "Forcibly quit"
     perClientProto addr =
       ("SomeOne", addr, serialiser <<-> digester <<-> attributor "someone")
     totalProto = shower "total"

--- a/src/Clapi/Attributor.hs
+++ b/src/Clapi/Attributor.hs
@@ -6,16 +6,17 @@ import Control.Monad (forever)
 import Data.Bifunctor (first)
 
 import Clapi.Protocol (Protocol, waitThen, sendFwd, sendRev)
-import Clapi.Types (Attributee, TrDigest(..), TrcDigest(..), DataChange(..))
+import Clapi.Types
+  (Attributee, TrDigest(..), TrcUpdateDigest(..), DataChange(..))
 
 attributor
   :: (Monad m, Functor f)
   => Attributee -> Protocol (f TrDigest) (f TrDigest) a a m ()
 attributor u = forever $ waitThen (sendFwd . fmap attributeClient) sendRev
   where
-    attributeClient (Trcd d) = Trcd $ d{
-      trcdContainerOps = fmap (first modAttr) <$> trcdContainerOps d,
-      trcdData = attributeDc <$> trcdData d}
+    attributeClient (Trcud d) = Trcud $ d{
+      trcudContOps = fmap (first modAttr) <$> trcudContOps d,
+      trcudData = attributeDc <$> trcudData d}
     attributeClient d = d
     attributeDc dc = case dc of
       ConstChange ma vs -> ConstChange (modAttr ma) vs

--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -40,8 +40,6 @@ import Clapi.PerClientProto (ClientEvent(..), ServerEvent(..))
 import Clapi.Protocol (Protocol, Directed(..), wait, sendFwd, sendRev)
 import Clapi.Util (flattenNestedMaps)
 
-data Ownership = Owner | Client deriving (Eq, Show)
-
 newtype Originator i = Originator i deriving (Eq, Show)
 
 data ClientGetDigest = ClientGetDigest

--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -35,7 +35,7 @@ import qualified Clapi.Types.Path as Path
 import Clapi.Types.SequenceOps (isSoAbsent)
 import Clapi.PerClientProto (ClientEvent(..), ServerEvent(..))
 import Clapi.Protocol (Protocol, Directed(..), wait, sendFwd, sendRev)
-import Clapi.Util (flattenNestedMaps)
+import Clapi.Util (flattenNestedMaps, nestMapsByKey)
 
 data Ownership = Owner | Client deriving (Eq, Show)
 
@@ -396,17 +396,6 @@ zipMaps6 fun ma mb mc md me mf =
   zipMaps (\(a, (b, c)) (d, (e, f)) -> fun a b c d e f)
   (zipMaps (,) ma (zipMaps (,) mb mc))
   (zipMaps (,) md (zipMaps (,) me mf))
-
-nestMapsByKey
-  :: (Ord k, Ord k0, Ord k1)
-  => (k -> Maybe (k0, k1)) -> Map k a -> (Map k a, Map k0 (Map k1 a))
-nestMapsByKey f = Map.foldlWithKey g mempty
-  where
-    g (unsplit, nested) k val = case f k of
-      Just (k0, k1) ->
-        ( unsplit
-        , Map.alter (Just . Map.insert k1 val . maybe mempty id) k0 nested)
-      Nothing -> (Map.insert k val unsplit, nested)
 
 nestAlByKey
   :: (Ord k, Ord k0, Ord k1)

--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -2,63 +2,88 @@ module Clapi.NamespaceTracker where
 
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
-import Control.Monad (forever, unless, void)
+import Control.Monad (forever, when, unless, void)
 import Control.Monad.State (StateT(..), evalStateT, get, put, modify)
 import Control.Monad.Trans (MonadTrans, lift)
+import Data.Foldable (foldl')
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Map.Strict.Merge (merge, zipWithMatched, mapMissing)
+import Data.Maybe (mapMaybe)
 import Data.Monoid
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Tagged (Tagged)
+import Data.Tagged (Tagged, untag)
 import qualified Data.Text as Text
 
 
-import Data.Map.Mos (Mos)
-import qualified Data.Map.Mos as Mos
 import Clapi.Types.AssocList
   (AssocList, alEmpty,  alFilterKey, alInsert, alFoldlWithKey, alKeysSet)
-import Clapi.Types.Messages (ErrorIndex(..))
+import Clapi.Types.Messages (DataErrorIndex(..))
 import Clapi.Types.Digests
-  ( TrDigest(..), TrcDigest(..), TrpDigest(..), TrprDigest(..)
-  , FrDigest(..), FrcDigest(..), frcdEmpty, FrpDigest(..), FrpErrorDigest(..)
-  , DefOp(..), SubOp(..), frcdNull, trcdNamespaces
-  , InboundDigest(..), InboundClientDigest(..), OutboundDigest(..)
-  , OutboundClientDigest(..), OutboundClientInitialisationDigest
-  , OutboundProviderDigest(..))
+  ( TrDigest(..), TrcSubDigest(..), trcsdNamespaces, TrcUpdateDigest(..)
+  , TrpDigest(..), TrprDigest(..)
+  , FrDigest(..), FrcSubDigest(..), FrcUpdateDigest(..)
+  , FrpDigest(..), FrpErrorDigest(..)
+  , DefOp(..), isUndef, isSub, frcudNull, frcsdNull, frcsdEmpty
+  , OutboundDigest(..)
+  , OutboundClientInitialisationDigest, OutboundClientUpdateDigest)
 -- Also `Either String a` MonadFail instance:
 import Clapi.Types (Definition, PostDefinition)
 import Clapi.Types.Path
-  (Path, TypeName(..), pattern (:/), pattern Root, Namespace(..))
+  ( Path, TypeName(..), pattern (:/), pattern (:</), pattern Root
+  , Namespace(..), Seg, unqualify, qualify)
 import qualified Clapi.Types.Path as Path
 import Clapi.Types.SequenceOps (isSoAbsent)
 import Clapi.PerClientProto (ClientEvent(..), ServerEvent(..))
 import Clapi.Protocol (Protocol, Directed(..), wait, sendFwd, sendRev)
-import Clapi.Util (flattenNestedMaps, nestMapsByKey)
+import Clapi.Util (flattenNestedMaps)
 
 data Ownership = Owner | Client deriving (Eq, Show)
 
 newtype Originator i = Originator i deriving (Eq, Show)
 
+data ClientGetDigest = ClientGetDigest
+  { cdgPostTypeGets :: Set (Tagged PostDefinition TypeName)
+  , cdgTypeGets :: Set (Tagged Definition TypeName)
+  , cgdDataGets :: Set Path
+  } deriving (Show, Eq)
+
+data PostNstInboundDigest
+  = PnidCgd ClientGetDigest
+  | PnidTrcud TrcUpdateDigest
+  | PnidTrpd TrpDigest
+  | PnidTrprd TrprDigest
+  deriving (Show, Eq)
+
 type NstProtocol m i = Protocol
     (ClientEvent i TrDigest)
-    ((Originator i, InboundDigest))
+    ((Originator i, PostNstInboundDigest))
     (Either (Map Namespace i) (ServerEvent i FrDigest))
     ((Originator i, OutboundDigest))
     m
 
+data ClientRegs
+  = ClientRegs
+  { crPostTypeRegs :: Set (Tagged PostDefinition TypeName)
+  , crTypeRegs :: Set (Tagged Definition TypeName)
+  , crDataRegs :: Set Path
+  } deriving (Show)
+
+instance Monoid ClientRegs where
+  mempty = ClientRegs mempty mempty mempty
+  (ClientRegs pt1 t1 d1) `mappend` (ClientRegs pt2 t2 d2) =
+    ClientRegs (pt1 <> pt2) (t1 <> t2) (d1 <> d2)
+
 data NstState i
   = NstState
   { nstOwners :: Map Namespace i
-  , nstPostTypeRegistrations :: Mos i (Tagged PostDefinition TypeName)
-  , nstTypeRegistrations :: Mos i (Tagged Definition TypeName)
-  , nstDataRegistrations :: Mos i Path
+  , nstRegs :: Map i ClientRegs
   } deriving Show
 
 
 nstProtocol :: (Monad m, Ord i) => NstProtocol m i ()
-nstProtocol = evalStateT nstProtocol_ $ NstState mempty mempty mempty mempty
+nstProtocol = evalStateT nstProtocol_ $ NstState mempty mempty
 
 nstProtocol_ :: (Monad m, Ord i) => StateT (NstState i) (NstProtocol m i) ()
 nstProtocol_ = forever $ liftedWaitThen fwd rev
@@ -68,31 +93,46 @@ nstProtocol_ = forever $ liftedWaitThen fwd rev
     fwd (ClientData i trd) =
       case trd of
         Trpd d -> claimNamespace i d
-          (throwOutProvider i (Set.singleton $ trpdNamespace d))
-          (sendFwd' i (Ipd d))
+          (throwOutProvider i $ Set.singleton $ trpdNamespace d)
+          (sendFwd' i $ PnidTrpd d)
         Trprd d -> relinquishNamespace i (trprdNamespace d)
-          (throwOutProvider i (Set.singleton $ trprdNamespace d))
-          (sendFwd' i (Iprd d))
-        Trcd d -> eitherState
-          (uncurry $ throwOutProvider i)
-          (const $ do
-              (icd, frcd) <- toInboundClientDigest i d
-              unless (frcdNull frcd) $
-                lift $ sendRev $ Right $ ServerData i $ Frcd frcd
-              sendFwd' i $ Icd icd
+          (throwOutProvider i $ Set.singleton $ trprdNamespace d)
+          (sendFwd' i $ PnidTrprd d)
+        Trcsd d -> guardNsClientSubDigest i d
+          (throwOutProvider i)
+          (do
+              (cgd, frcsd) <- handleSubDigest i d
+              unless (frcsdNull frcsd) $
+                lift $ sendRev $ Right $ ServerData i $ Frcsd frcsd
+              sendFwd' i $ PnidCgd cgd
           )
-          (guardNsClientDigest i d)
+        Trcud d -> guardNsClientUpdateDigest i d
+          (throwOutProvider i $ Set.singleton $ trcudNamespace d)
+          (sendFwd' i $ PnidTrcud d)
     fwd (ClientDisconnect i) = handleDisconnect i
-    rev (Originator i, od) = case od of
-      Ocid d -> registerSubs i d
-        >> lift (sendRev $ Right $ ServerData i $ Frcd $ subResponse d)
-      Ocd d -> unsubDeleted d >>= lift . broadcastClientDigest d
-      Opd d -> dispatchProviderDigest d
-      Ope d -> (lift $ sendRev $ Right $ ServerData i $ Frped d)
-        >> (lift $ sendRev $ Right $ ServerDisconnect i) >> handleDisconnect i
+    rev (Originator i, od) =
+      let send i' = lift . sendRev . Right . ServerData i' in case od of
+        Ocid d -> registerSubs i d >> send i (Frcud d)
+        Ocsed errMap -> send i $ Frcsd $ frcsdEmpty { frcsdErrors = errMap}
+        -- FIXME: eventually we may collapse the client/time tracking roles of
+        -- the RelayAPI, perhaps to here, and then this, which is really a
+        -- broadcast, could happen here. Right now, we don't actually have info
+        -- about all the connected clients:
+        Ocrd d -> send i $ Frcrd d
+        Ocud d -> do
+          generateClientDigests d >>= lift . broadcastRev . fmap Frcud
+          unsubDeleted d >>= lift . broadcastRev . fmap Frcsd
+        Opd d -> do
+          i' <- maybe (error "no owner for namespace") id .
+            Map.lookup (frpdNamespace d) . nstOwners <$> get
+          send i' $ Frpd d
+        Ope d -> do
+          send i $ Frped d
+          lift $ sendRev $ Right $ ServerDisconnect i
+          handleDisconnect i
 
 nonClaim :: TrpDigest -> Bool
-nonClaim trpd = trpdData trpd == alEmpty && null (trpdContainerOps trpd)
+nonClaim trpd = trpdData trpd == alEmpty && null (trpdContOps trpd)
 
 updateOwners
   :: Monad m => Map Namespace i ->  StateT (NstState i) (NstProtocol m i) ()
@@ -105,9 +145,8 @@ throwOutProvider
   => i -> Set Namespace -> String -> StateT (NstState i) (NstProtocol m i) ()
 throwOutProvider i nss msg = do
   lift $ sendRev $ Right $ ServerData i $ Frped $ FrpErrorDigest $
-    Set.foldl (\acc ns ->
-      Map.insert (PathError $ Root :/ unNamespace ns) [Text.pack msg] acc)
-    mempty nss
+    Map.fromSet (const [Text.pack msg]) $
+    Set.map (PathError . (Root :/) . unNamespace) nss
   lift $ sendRev $ Right $ ServerDisconnect i
   handleDisconnect i
 
@@ -126,12 +165,12 @@ claimNamespace
   -> (String -> StateT (NstState i) (NstProtocol m i) ())
   -> StateT (NstState i) (NstProtocol m i) ()
   -> StateT (NstState i) (NstProtocol m i) ()
-claimNamespace i d failureAction successAction = get >>= either
+claimNamespace i d failureAction successAction = either
     failureAction
     (\owners' ->
       maybe (return ()) updateOwners owners' >>
       successAction)
-    . go . nstOwners
+    . go . nstOwners =<< get
   where
     go owners =
       let
@@ -152,10 +191,10 @@ relinquishNamespace
   -> (String -> StateT (NstState i) (NstProtocol m i) ())
   -> StateT (NstState i) (NstProtocol m i) ()
   -> StateT (NstState i) (NstProtocol m i) ()
-relinquishNamespace i ns failureAction successAction = get >>= either
+relinquishNamespace i ns failureAction successAction = either
     failureAction
     (\owners' -> updateOwners owners' >> successAction)
-    . go . nstOwners
+    . go . nstOwners =<< get
   where
     go owners =
       let
@@ -168,57 +207,64 @@ relinquishNamespace i ns failureAction successAction = get >>= either
             then return owners'
             else fail "You're not the owner"
 
-guardNsClientDigest
-  :: Eq i
-  => i -> TrcDigest -> StateT (NstState i) (Either (Set Namespace, String)) ()
-guardNsClientDigest i d =
-  let
-    nss = trcdNamespaces d
-    getBadNss = Map.keysSet . Map.filter (== i) . flip Map.restrictKeys nss
-  in do
-    nsts <- get
-    let ownedAndMentioned = getBadNss $ nstOwners nsts
-    lift $ unless (null $ ownedAndMentioned) $
-      Left (ownedAndMentioned, "Acted as client on own namespace")
-
-toInboundClientDigest
-  :: (Ord i, Monad m)
-  => i -> TrcDigest -> StateT (NstState i) m (InboundClientDigest, FrcDigest)
-toInboundClientDigest i trcd =
-  let
-    isSub OpSubscribe = True
-    isSub OpUnsubscribe = False
-    (dSubs, dUnsubs) = mapPair Map.keysSet $ Map.partition isSub $ trcdDataSubs trcd
-    (ptSubs, ptUnsubs) = mapPair Map.keysSet $ Map.partition isSub $ trcdPostTypeSubs trcd
-    (tSubs, tUnsubs) = mapPair Map.keysSet $ Map.partition isSub $ trcdTypeSubs trcd
-  in do
-    nsts <- get
-    put nsts{
-      nstDataRegistrations = Mos.difference
-        (nstDataRegistrations nsts) (Map.singleton i dUnsubs),
-      nstPostTypeRegistrations = Mos.difference
-        (nstPostTypeRegistrations nsts) (Map.singleton i ptUnsubs),
-      nstTypeRegistrations = Mos.difference
-        (nstTypeRegistrations nsts) (Map.singleton i tUnsubs)}
-    let icd = InboundClientDigest
-          (Set.difference dSubs $
-            Map.findWithDefault mempty i $ nstDataRegistrations nsts)
-          (Set.difference ptSubs $
-            Map.findWithDefault mempty i $ nstPostTypeRegistrations nsts)
-          (Set.difference tSubs $
-            Map.findWithDefault mempty i $ nstTypeRegistrations nsts)
-          (trcdContainerOps trcd)
-          (trcdData trcd)
-    let frcd = frcdEmpty
-          { frcdPostTypeUnsubs = Set.intersection ptUnsubs $
-              Map.findWithDefault mempty i $ nstPostTypeRegistrations nsts
-          , frcdTypeUnsubs = Set.intersection tUnsubs $
-              Map.findWithDefault mempty i $ nstTypeRegistrations nsts
-          , frcdDataUnsubs = Set.intersection dUnsubs $
-            Map.findWithDefault mempty i $ nstDataRegistrations nsts}
-    return (icd, frcd)
+guardNsClientSubDigest
+  :: (Eq i, Monad m)
+  => i -> TrcSubDigest
+  -> (Set Namespace -> String -> StateT (NstState i) (NstProtocol m i) ())
+  -> StateT (NstState i) (NstProtocol m i) ()
+  -> StateT (NstState i) (NstProtocol m i) ()
+guardNsClientSubDigest i d failureAction successAction = either
+    (uncurry failureAction)
+    (const successAction)
+    . go . nstOwners =<< get
   where
-    mapPair f (a, b) = (f a, f b)
+    go owners =
+      let
+        ownedAndSubd = Map.keysSet $ Map.filter (== i) $ Map.restrictKeys owners
+          $ trcsdNamespaces d
+      in
+        unless (null ownedAndSubd) $
+          Left (ownedAndSubd, "Acted as client on own namespace")
+
+guardNsClientUpdateDigest
+  :: (Eq i, Monad m)
+  => i -> TrcUpdateDigest
+  -> (String -> StateT (NstState i) (NstProtocol m i) ())
+  -> StateT (NstState i) (NstProtocol m i) ()
+  -> StateT (NstState i) (NstProtocol m i) ()
+guardNsClientUpdateDigest i d failureAction successAction = either
+    failureAction
+    (const successAction)
+    . go . nstOwners =<< get
+  where
+    go owners = maybe
+      (return ())
+      (\i' -> when (i' == i) $ fail "Acted as client on own namespace")
+      $ Map.lookup (trcudNamespace d) owners
+
+handleSubDigest
+  :: (Monad m, Ord i)
+  => i -> TrcSubDigest -> StateT (NstState i) m (ClientGetDigest, FrcSubDigest)
+handleSubDigest i trcsd =
+  let
+    (ptSubs, ptUnsubs) = partSubs $ trcsdPostTypeSubs trcsd
+    (tSubs, tUnsubs) = partSubs $ trcsdTypeSubs trcsd
+    (dSubs, dUnsubs) = partSubs $ trcsdDataSubs trcsd
+  in do
+    nsts <- get
+    let current = Map.findWithDefault mempty i $ nstRegs nsts
+    let cdg = ClientGetDigest
+          (Set.difference ptSubs $ crPostTypeRegs current)
+          (Set.difference tSubs $ crTypeRegs current)
+          (Set.difference dSubs $ crDataRegs current)
+    let frcsd = FrcSubDigest mempty
+          (Set.intersection ptUnsubs $ crPostTypeRegs current)
+          (Set.intersection tUnsubs $ crTypeRegs current)
+          (Set.intersection dUnsubs $ crDataRegs current)
+    return (cdg, frcsd)
+  where
+    mapPair f (a1, a2) = (f a1, f a2)
+    partSubs = mapPair Map.keysSet . Map.partition isSub
 
 handleDisconnect
   :: (Ord i, Monad m) => i -> StateT (NstState i) (NstProtocol m i) ()
@@ -228,134 +274,87 @@ handleDisconnect i = do
     unless (null removed) $ updateOwners remaining
     mapM_ send $ Map.keys removed
   where
-    send ns = lift $ sendFwd (Originator i, Iprd $ TrprDigest ns)
+    send ns = lift $ sendFwd (Originator i, PnidTrprd $ TrprDigest ns)
 
 registerSubs
   :: (Ord i, Monad m)
   => i -> OutboundClientInitialisationDigest -> StateT (NstState i) m ()
-registerSubs i (OutboundClientDigest cas postDefs defs _tas dd _errs) =
+registerSubs i (FrcUpdateDigest ns postDefs defs _tas dd cops _errs) =
     modify go
   where
-    newDRegsForI = Set.union (Map.keysSet cas) (alKeysSet dd)
-    go (NstState owners ptRegs tRegs dRegs) = NstState owners
-      (Map.insertWith (<>) i (Map.keysSet postDefs) ptRegs)
-      (Map.insertWith (<>) i (Map.keysSet defs) tRegs)
-      (Map.insertWith (<>) i newDRegsForI dRegs)
-
-subResponse :: OutboundClientInitialisationDigest -> FrcDigest
-subResponse (OutboundClientDigest cOps postDefs defs tas dd errs) =
-    FrcDigest postTypesInError typesInError pathsInError postDefs defs tas dd
-    cOps errs
-  where
-    (pathsInError, postTypesInError, typesInError) =
-        foldl collectError mempty $ Map.keys errs
-    collectError (pie, ptie, tie) ei = case ei of
-        PathError p -> (Set.insert p pie, ptie, tie)
-        PostTypeError t -> (pie, Set.insert t ptie, tie)
-        TypeError t -> (pie, ptie, Set.insert t tie)
-        _ -> (pie, ptie, tie)
+    newClientRegs = ClientRegs
+      (Set.map (qualify ns) $ Map.keysSet postDefs)
+      (Set.map (qualify ns) $ Map.keysSet defs)
+      (Set.map (unNamespace ns :</) $
+       Set.union (Map.keysSet cops) (alKeysSet dd))
+    go nsts = nsts {
+      nstRegs = Map.insertWith (<>) i newClientRegs $ nstRegs nsts}
 
 unsubDeleted
-  :: (Monad m, Ord i) => OutboundClientDigest
-  -> StateT (NstState i) m
-       ( Mos i (Tagged PostDefinition TypeName)
-       , Mos i (Tagged Definition TypeName)
-       , Mos i (Tagged PostDefinition TypeName)
-       , Mos i (Tagged Definition TypeName)
-       , Mos i Path, Mos i Path)
+  :: (Monad m, Ord i)
+  => OutboundClientUpdateDigest -> StateT (NstState i) m (Map i FrcSubDigest)
 unsubDeleted d = do
     nsts <- get
-    let (ptUnsubs, ptRemainingSubs) = Mos.partition
-          (`Set.member` allUndefPTys) $ nstPostTypeRegistrations nsts
-    let (tUnsubs, tRemainingSubs) = Mos.partition
-          (`Set.member` allUndefTys) $ nstTypeRegistrations nsts
-    let (dUnsubs, dRemainingSubs) = Mos.partition
-          (`Path.isChildOfAny` allDeletePaths) $ nstDataRegistrations nsts
-    put $ nsts
-      { nstDataRegistrations = dRemainingSubs
-      , nstPostTypeRegistrations = ptRemainingSubs
-      , nstTypeRegistrations = tRemainingSubs
-      }
-    return
-      ( ptUnsubs, tUnsubs
-      , ptRemainingSubs, tRemainingSubs
-      , dUnsubs, dRemainingSubs
-      )
+    let results = fmap updateClientReg $ nstRegs nsts
+    put nsts{ nstRegs = fmap fst results }
+    return $ fmap snd results
   where
-    allUndefPTys = Map.keysSet $ Map.filter isUndefTy $ ocdPostDefs d
-    allUndefTys = Map.keysSet $ Map.filter isUndefTy $ ocdDefinitions d
-    isUndefTy defOp = case defOp of
-      OpUndefine -> True
-      _ -> False
-    allDeletePaths = Map.keys $ flattenNestedMaps (:/) $
-      Map.filter isSoAbsent . fmap snd <$> ocdContainerOps d
+    ns = frcudNamespace d
+    allUndefPTys = qualifiedUndefs $ frcudPostDefs d
+    allUndefTys = qualifiedUndefs $ frcudDefinitions d
+    qualifiedUndefs :: Map (Tagged a Seg) (DefOp a) -> Set (Tagged a TypeName)
+    qualifiedUndefs = Set.map (qualify ns) . Map.keysSet . Map.filter isUndef
+    allDeletePaths = Set.map (unNamespace ns :</) $ Map.keysSet $
+      flattenNestedMaps (:/) $
+      Map.filter isSoAbsent . fmap snd <$> frcudContOps d
+    updateClientReg :: ClientRegs -> (ClientRegs, FrcSubDigest)
+    updateClientReg (ClientRegs ptSubs tSubs dSubs) =
+      let
+        (ptUnsubs, ptSubs') = Set.partition (`Set.member` allUndefPTys) ptSubs
+        (tUnsubs, tSubs') = Set.partition (`Set.member` allUndefTys) tSubs
+        (dUnsubs, dSubs') = Set.partition (`Set.member` allDeletePaths) dSubs
+      in
+        ( ClientRegs ptSubs' tSubs' dSubs'
+        , FrcSubDigest mempty ptUnsubs tUnsubs dUnsubs
+        )
 
-broadcastClientDigest
-  :: (Ord i, Monad m)
-  => OutboundClientDigest
-  -> ( Mos i (Tagged PostDefinition TypeName)
-     , Mos i (Tagged Definition TypeName)
-     , Mos i (Tagged PostDefinition TypeName)
-     , Mos i (Tagged Definition TypeName)
-     , Mos i Path, Mos i Path)
-  -> NstProtocol m i ()
-broadcastClientDigest d
-  (ptUnsubs, tUnsubs, ptRemSubs, tRemSubs, dUnsubs, dRemSubs) = do
-    let fromRelayClientDigests = Map.filter (not . frcdNull) $ zipMaps6
-          (produceFromRelayClientDigest d) dUnsubs ptUnsubs tUnsubs dRemSubs
-          ptRemSubs tRemSubs
-    void $ sequence $ Map.mapWithKey sendRevWithI fromRelayClientDigests
+broadcastRev :: Monad m => Map i FrDigest -> NstProtocol m i ()
+broadcastRev = void . sequence . Map.mapWithKey sendRevWithI
   where
-    sendRevWithI i frcd = sendRev $ Right $ ServerData i $ Frcd frcd
+    sendRevWithI i digest = sendRev $ Right $ ServerData i digest
 
-dispatchProviderDigest
+generateClientDigests
   :: Monad m
-  => OutboundProviderDigest -> StateT (NstState i) (NstProtocol m i) ()
-dispatchProviderDigest d =
-  let
-    send i = lift . sendRev . Right . ServerData i . Frpd
-  in do
-    nsts <- get
-    let dispatch ns =
-          maybe (error "no owner for namespace") send
-          $ Map.lookup ns $ nstOwners nsts
-    void $ sequence $ Map.mapWithKey dispatch $ frpdsByNamespace d
-
-frpdsByNamespace :: OutboundProviderDigest -> Map Namespace FrpDigest
-frpdsByNamespace (OutboundProviderDigest contOps dd) =
-  let
-    (rootCOps, casByNs) = nestMapsByKey Path.splitHead contOps
-    (_, ddByNs) = nestAlByKey Path.splitHead dd
-    -- FIXME: whacking the global stuff to everybody isn't quite right - we need
-    -- to know who originated the opd?
-    f ns contOps' dd' = FrpDigest ns dd' (contOps' <> rootCOps)
-  in
-    zipMapsWithKey mempty alEmpty f
-      (Map.mapKeys Namespace casByNs)
-      (Map.mapKeys Namespace ddByNs)
-
-produceFromRelayClientDigest
-  :: OutboundClientDigest -> Set Path -> Set (Tagged PostDefinition TypeName)
-  -> Set (Tagged Definition TypeName)
-  -> Set Path -> Set (Tagged PostDefinition TypeName)
-  -> Set (Tagged Definition TypeName) -> FrcDigest
-produceFromRelayClientDigest
-  (OutboundClientDigest cOps postDefs defs tas dd errs) pUsubs ptUnsubs tUsubs
-  ps ptns tns = FrcDigest
-    ptUnsubs tUsubs pUsubs
-    (Map.restrictKeys postDefs ptns)
-    (Map.restrictKeys defs tns)
-    (Map.restrictKeys tas ps)
-    (alFilterKey (`Set.member` ps) dd)
-    (Map.restrictKeys cOps ps)
-    (Map.filterWithKey relevantErr errs)
+  => OutboundClientUpdateDigest -> StateT (NstState i) m (Map i FrcUpdateDigest)
+generateClientDigests (FrcUpdateDigest ns ptds tds tas d cops errs) =
+    Map.filter (not . frcudNull) . fmap filterFrcud . nstRegs <$> get
   where
-    relevantErr ei _ = case ei of
-      GlobalError -> True
-      PathError p -> p `Set.member` ps
-      TimePointError p _ -> p `Set.member` ps
-      PostTypeError tn -> tn `Set.member` ptns
-      TypeError tn -> tn `Set.member` tns
+    ttnOfInterest :: Tagged a TypeName -> Bool
+    ttnOfInterest = (== ns) . tnNamespace . untag
+    unqualTySubs :: Set (Tagged a TypeName) -> Set (Tagged a Seg)
+    unqualTySubs = foldl' (\acc ttn ->
+      if ttnOfInterest ttn
+        then Set.insert (snd $ unqualify ttn) acc
+        else acc
+      ) mempty
+    filterFrcud :: ClientRegs -> FrcUpdateDigest
+    filterFrcud (ClientRegs ptSubs tSubs dSubs) =
+      let
+        unqualdDatSubs = Set.fromAscList $ mapMaybe (fmap snd . Path.splitHead)
+          $ filter (`Path.isChildOf` (Root :/ unNamespace ns))
+          $ Set.toAscList dSubs
+      in
+      FrcUpdateDigest ns
+      (Map.restrictKeys ptds $ unqualTySubs ptSubs)
+      (Map.restrictKeys tds $ unqualTySubs tSubs)
+      (Map.restrictKeys tas unqualdDatSubs)
+      (alFilterKey (`Set.member` unqualdDatSubs) d)
+      (Map.restrictKeys cops unqualdDatSubs)
+      (Map.filterWithKey  (\dem _ -> case dem of
+        GlobalError -> True
+        PathError p -> p `Set.member` unqualdDatSubs
+        TimePointError p _ -> p `Set.member` unqualdDatSubs)
+        errs)
 
 liftedWaitThen ::
   (Monad m, MonadTrans t, Monad (t (Protocol a a' b' b m))) =>
@@ -380,22 +379,6 @@ zipMaps
   :: (Ord k, Monoid a, Monoid b)
   => (a -> b -> c) -> Map k a -> Map k b -> Map k c
 zipMaps f = zipMapsWithKey mempty mempty $ const f
-
-zipMaps4
-  :: (Ord k, Monoid a, Monoid b, Monoid c, Monoid d)
-  => (a -> b -> c -> d -> e) -> Map k a -> Map k b -> Map k c -> Map k d
-  -> Map k e
-zipMaps4 f ma mb mc md = zipMaps (\(a, b) (c, d) -> f a b c d)
-  (zipMaps (,) ma mb) (zipMaps (,) mc md)
-
-zipMaps6
-  :: (Ord k, Monoid a, Monoid b, Monoid c, Monoid d, Monoid e, Monoid f)
-  => (a -> b -> c -> d -> e -> f -> g) -> Map k a -> Map k b -> Map k c
-  -> Map k d -> Map k e -> Map k f -> Map k g
-zipMaps6 fun ma mb mc md me mf =
-  zipMaps (\(a, (b, c)) (d, (e, f)) -> fun a b c d e f)
-  (zipMaps (,) ma (zipMaps (,) mb mc))
-  (zipMaps (,) md (zipMaps (,) me mf))
 
 nestAlByKey
   :: (Ord k, Ord k0, Ord k1)

--- a/src/Clapi/NamespaceTracker.hs
+++ b/src/Clapi/NamespaceTracker.hs
@@ -44,10 +44,13 @@ data Ownership = Owner | Client deriving (Eq, Show)
 newtype Originator i = Originator i deriving (Eq, Show)
 
 data ClientGetDigest = ClientGetDigest
-  { cdgPostTypeGets :: Set (Tagged PostDefinition TypeName)
-  , cdgTypeGets :: Set (Tagged Definition TypeName)
+  { cgdPostTypeGets :: Set (Tagged PostDefinition TypeName)
+  , cgdTypeGets :: Set (Tagged Definition TypeName)
   , cgdDataGets :: Set Path
   } deriving (Show, Eq)
+
+cgdEmpty :: ClientGetDigest
+cgdEmpty = ClientGetDigest mempty mempty mempty
 
 data PostNstInboundDigest
   = PnidCgd ClientGetDigest

--- a/src/Clapi/Relay.hs
+++ b/src/Clapi/Relay.hs
@@ -245,32 +245,6 @@ relay vs = waitThenFwdOnly fwd
             unless (null $ frcrdContOps frcrd) $
                 sendRev (i, Ocrd frcrd)
             relay vs'
-        -- handleClientDigest
-        --     (InboundClientDigest ns gets postTypeGets typeGets contOps dd)
-        --     errMap = undefined
-        --   let
-        --     -- TODO: Be more specific in what we reject (filtering by TpId
-        --     -- rather than entire path)
-        --     eidxPath eidx = case eidx of
-        --         PathError p -> Just p
-        --         TimePointError p _ -> Just p
-        --         _ -> Nothing
-        --     errPaths = Set.fromList $ mapMaybe eidxPath $ Map.keys errMap
-        --     dd' = alFilterKey (\k -> not $ Set.member k errPaths) dd
-        --     contOps' = Map.filterWithKey
-        --       (\k _ -> not $ Set.member k errPaths) contOps
-        --     dd'' = vsMinimiseDataDigest dd' vs
-        --     contOps'' = vsMinimiseContOps contOps' vs
-        --     -- FIXME: above uses errors semantically and shouldn't (thus throws
-        --     -- away valid time point changes)
-        --     cid = genInitDigest gets postTypeGets typeGets vs
-        --     cid' = cid{ocdErrors =
-        --       Map.unionWith (<>) (ocdErrors cid) (fmap (Text.pack . show) <$> errMap)}
-        --     opd = OutboundProviderDigest contOps'' dd''
-        --   in do
-        --     unless (ocdNull cid') $ sendRev (i, Ocid cid')
-        --     unless (opdNull opd) $ sendRev (i, Opd opd)
-        --     relay vs
         terminalErrors errMap = do
           sendRev (i, Ope $ FrpErrorDigest errMap)
           relay vs

--- a/src/Clapi/Relay.hs
+++ b/src/Clapi/Relay.hs
@@ -198,10 +198,12 @@ relay
 relay vs = waitThenFwdOnly fwd
   where
     fwd (i, dig) = case dig of
-        PnidRootGet -> sendRev
-            ( i
-            , Ocrid $ FrcRootDigest $ Map.fromSet (const $ SoAfter Nothing) $
-              Set.fromList $ treeChildNames $ vsTree vs)
+        PnidRootGet -> do
+            sendRev
+              ( i
+              , Ocrid $ FrcRootDigest $ Map.fromSet (const $ SoAfter Nothing) $
+                Set.fromList $ treeChildNames $ vsTree vs)
+            relay vs
         PnidCgd cgd ->
           let (ocsed, ocids) = genInitDigests cgd vs in do
             unless (ocsedNull ocsed) $ sendRev (i, Ocsed ocsed)

--- a/src/Clapi/Serialisation/Definitions.hs
+++ b/src/Clapi/Serialisation/Definitions.hs
@@ -9,7 +9,7 @@ import Clapi.TaggedData (TaggedData, taggedData)
 import Clapi.TextSerialisation (ttToText, ttFromText)
 import Clapi.TH (btq)
 import Clapi.Types.Definitions
-  ( Liberty(..), Required(..), MetaType(..), metaType
+  ( Liberty(..), Editable(..), MetaType(..), metaType
   , TupleDefinition(..), StructDefinition(..), ArrayDefinition(..)
   , Definition(..), defDispatch, PostDefinition(..))
 import Clapi.Types.Tree (TreeType)
@@ -26,16 +26,16 @@ instance Encodable Liberty where
   builder = tdTaggedBuilder libertyTaggedData $ const $ return mempty
   parser = tdTaggedParser libertyTaggedData return
 
-requiredTaggedData :: TaggedData Required Required
-requiredTaggedData = taggedData toTag id
+editableTaggedData :: TaggedData Editable Editable
+editableTaggedData = taggedData toTag id
   where
     toTag r = case r of
-      Required -> [btq|r|]
-      Optional -> [btq|o|]
+      Editable -> [btq|w|]
+      ReadOnly -> [btq|r|]
 
-instance Encodable Required where
-  builder = tdTaggedBuilder requiredTaggedData $ const $ return mempty
-  parser = tdTaggedParser requiredTaggedData return
+instance Encodable Editable where
+  builder = tdTaggedBuilder editableTaggedData $ const $ return mempty
+  parser = tdTaggedParser editableTaggedData return
 
 -- FIXME: do we want to serialise the type to text first?!
 instance Encodable TreeType where
@@ -52,9 +52,9 @@ instance Encodable StructDefinition where
   parser = StructDefinition <$> parser <*> parser
 
 instance Encodable ArrayDefinition where
-  builder (ArrayDefinition doc ct cl) =
-    builder doc <<>> builder ct <<>> builder cl
-  parser = ArrayDefinition <$> parser <*> parser <*> parser
+  builder (ArrayDefinition doc ptn ctn cl) =
+    builder doc <<>> builder ptn <<>> builder ctn <<>> builder cl
+  parser = ArrayDefinition <$> parser <*> parser <*> parser <*> parser
 
 defTaggedData :: TaggedData MetaType Definition
 defTaggedData = taggedData typeToTag (defDispatch metaType)

--- a/src/Clapi/Serialisation/Path.hs
+++ b/src/Clapi/Serialisation/Path.hs
@@ -15,6 +15,8 @@ instance Encodable Path.Seg where
   builder = builder . Path.unSeg
   parser = parser >>= Path.mkSeg
 
+deriving instance Encodable Path.Placeholder
+
 instance Encodable Path.Path where
   builder = builder . Path.toText Path.unSeg
   parser = parser >>= Path.fromText Path.segP

--- a/src/Clapi/Server.hs
+++ b/src/Clapi/Server.hs
@@ -17,6 +17,7 @@ import GHC.IO.Exception (IOException)
 import qualified Network.Socket as NS
 import qualified Network.Socket.ByteString as NSB
 import Network.Simple.TCP (HostPreference, bindSock)
+import System.IO (hPutStrLn, stderr)
 
 import Clapi.Protocol (Protocol, runProtocolIO)
 import Clapi.PerClientProto
@@ -101,7 +102,9 @@ protocolServer
 protocolServer listenSock getClientProto mainProto onShutdown = do
     (mainI, mainO) <- BQ.newChan 4
     clientMap <- newMVar mempty
-    withAsync (mainP mainO clientMap) (clientP mainI clientMap)
+    withAsync
+      (mainP mainO clientMap >> hPutStrLn stderr "WARNING: main pipeline exited")
+      (clientP mainI clientMap)
   where
     mainP mainChan clientMap = runProtocolIO
         (BQ.readChan mainChan) undefined

--- a/src/Clapi/Tree.hs
+++ b/src/Clapi/Tree.hs
@@ -58,6 +58,9 @@ treeChildren t = case t of
     RtContainer al -> snd <$> al
     _ -> alEmpty
 
+treeChildNames :: RoseTree a -> [Seg]
+treeChildNames = fmap fst . unAssocList . treeChildren
+
 -- FIXME: define in terms of treeChildren (if even used)
 treePaths :: Path -> RoseTree a -> [Path]
 treePaths p t = case t of

--- a/src/Clapi/Tree.hs
+++ b/src/Clapi/Tree.hs
@@ -9,7 +9,7 @@ module Clapi.Tree where
 
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
-import Control.Monad.State (State, get, put, modify, runState)
+import Control.Monad.State (State, get, put, modify, runState, state)
 import Data.Functor.Const (Const(..))
 import Data.Functor.Identity (Identity(..))
 import Data.Map (Map)
@@ -29,8 +29,8 @@ import qualified Clapi.Types.Dkmap as Dkmap
 import Clapi.Types.Path (
     Seg, Path, pattern Root, pattern (:/), pattern (:</))
 import Clapi.Types.Digests
-  ( DataDigest, ContainerOps, DataChange(..), TimeSeriesDataOp(..))
-import Clapi.Types.SequenceOps (SequenceOp, updateUniqList, isSoCreate)
+  ( DataDigest, ContOps, DataChange(..), TimeSeriesDataOp(..))
+import Clapi.Types.SequenceOps (SequenceOp, updateUniqList)
 
 type TpId = Word32
 
@@ -69,7 +69,7 @@ treePaths p t = case t of
 
 treeApplyReorderings
   :: MonadFail m
-  => Map Seg (Maybe Attributee, SequenceOp Seg args) -> RoseTree a
+  => Map Seg (Maybe Attributee, SequenceOp Seg) -> RoseTree a
   -> m (RoseTree a)
 treeApplyReorderings contOps (RtContainer children) =
   let
@@ -77,7 +77,7 @@ treeApplyReorderings contOps (RtContainer children) =
     childMap = Map.foldlWithKey'
         (\acc k att -> Map.insert k (att, RtEmpty) acc)
         (alToMap children)
-        (fst <$> Map.filter (isSoCreate . snd) contOps)
+        (fst <$> contOps)
     reattribute s (oldMa, rt) = (Map.findWithDefault oldMa s attMap, rt)
   in
     RtContainer . alFmapWithKey reattribute . alPickFromMap childMap
@@ -146,21 +146,26 @@ treeAlterF att f path tree = maybe tree snd <$> inner path (Just (att, tree))
     buildChildTree s p =
       fmap ((att,) . RtContainer . alSingleton s) <$> inner p Nothing
 
--- FIXME: Maybe reorder the args to reflect application order?
-updateTreeWithDigest
-  :: ContainerOps args -> DataDigest -> RoseTree [WireValue]
-  -> (Map Path [Text], RoseTree [WireValue])
-updateTreeWithDigest contOps dd = runState $ do
-    errs <- alToMap <$> (sequence $ alFmapWithKey applyDd dd)
-    errs' <- sequence $ Map.mapWithKey applyContOp contOps
-    return $ Map.filter (not . null) $ Map.unionWith (<>) errs errs'
+updateTreeStructure
+  :: ContOps Seg -> RoseTree a -> (Map Path [Text], RoseTree a)
+updateTreeStructure contOps = runState $ do
+    errs <- sequence $ Map.mapWithKey applyContOp contOps
+    return $ Map.filter (not . null) errs
   where
     applyContOp
-      :: Path -> Map Seg (Maybe Attributee, SequenceOp Seg args)
-      -> State (RoseTree [WireValue]) [Text]
+      :: Path -> Map Seg (Maybe Attributee, SequenceOp Seg)
+      -> State (RoseTree a) [Text]
     applyContOp np m = do
       eRt <- treeAdjustF Nothing (treeApplyReorderings m) np <$> get
       either (return . pure . Text.pack) (\rt -> put rt >> return []) eRt
+
+updateTreeData
+  :: DataDigest -> RoseTree [WireValue]
+  -> (Map Path [Text], RoseTree [WireValue])
+updateTreeData dd = runState $ do
+    errs <- alToMap <$> (sequence $ alFmapWithKey applyDd dd)
+    return $ Map.filter (not . null) errs
+  where
     applyDd
       :: Path -> DataChange
       -> State (RoseTree [WireValue]) [Text]
@@ -181,6 +186,16 @@ updateTreeWithDigest contOps dd = runState $ do
         either (return . pure . Text.pack) (\vs -> put vs >> return [])
         . treeAdjustF Nothing (treeRemove tpId) np
 
+
+-- FIXME: Maybe reorder the args to reflect application order?
+updateTreeWithDigest
+  :: ContOps Seg -> DataDigest -> RoseTree [WireValue]
+  -> (Map Path [Text], RoseTree [WireValue])
+updateTreeWithDigest contOps dd = runState $ do
+    errs <- state (updateTreeData dd)
+    errs' <- state (updateTreeStructure contOps)
+    return $ Map.unionWith (<>) errs errs'
+
 data RoseTreeNode a
   = RtnEmpty
   | RtnChildren (AssocList Seg (Maybe Attributee))
@@ -188,6 +203,9 @@ data RoseTreeNode a
   | RtnDataSeries (TimeSeries a)
   deriving (Show, Eq)
 
+-- FIXME: perhaps this should return Maybe (RoseTreeNode a), and the RtEmpty
+-- case return Nothing, because the only place we use RtnEmpty we don't actually
+-- want a node!
 roseTreeNode :: RoseTree a -> RoseTreeNode a
 roseTreeNode t = case t of
   RtEmpty -> RtnEmpty

--- a/src/Clapi/Types/AssocList.hs
+++ b/src/Clapi/Types/AssocList.hs
@@ -40,6 +40,12 @@ mkAssocList abPairs = ensureUnique "keys" (fmap fst abPairs) >> return (AssocLis
 unsafeMkAssocList :: [(a, b)] -> AssocList a b
 unsafeMkAssocList = AssocList
 
+instance Eq a => Monoid (AssocList a b) where
+  mempty = AssocList []
+  al1 `mappend` (AssocList l2) =
+    Foldable.foldl' (\acc (a, b) -> alInsert a b acc) al1 l2
+
+-- FIXME: remove at some point now we have defined a monoid instance?
 alEmpty :: AssocList a b
 alEmpty = AssocList []
 
@@ -52,7 +58,7 @@ alFromKeys f as = AssocList $ (\a -> (a, f a)) <$> unUniqList as
 -- | Like `Map.fromList`, in that it doesn't fail but takes the final value for
 --   any duplicated key. Use `mkAssocList` to check for uniqueness.
 alFromList :: Eq a => [(a, b)] -> AssocList a b
-alFromList = foldl (\acc (k, a) -> alInsert k a acc) alEmpty
+alFromList = foldl (\acc (k, a) -> alInsert k a acc) mempty
 
 alFromMap :: Map a b -> AssocList a b
 alFromMap = AssocList . Map.toList

--- a/src/Clapi/Types/AssocList.hs
+++ b/src/Clapi/Types/AssocList.hs
@@ -10,6 +10,7 @@ module Clapi.Types.AssocList
   , alToMap, alFromZip
   , alCons, alLookup, alInsert, alSetDefault, alDelete
   , alKeys, alKeysSet, alValues
+  , alPartitionWithKey
   , alFmapWithKey, alMapKeys, alFilterWithKey, alFoldlWithKey,  alFilterKey
   , alAlterF, alAlter, alAdjust
   ) where
@@ -18,6 +19,7 @@ import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
 import qualified Data.Foldable as Foldable
 import Data.Functor.Identity (Identity(..))
+import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes)
@@ -109,6 +111,12 @@ alMapKeys f = mkAssocList . fmap (\(a, b) -> (f a, b)) . unAssocList
 
 alFoldlWithKey :: (acc -> k -> b -> acc) -> acc -> AssocList k b -> acc
 alFoldlWithKey f acc = foldl (\acc' (k, b) -> f acc' k b) acc . unAssocList
+
+alPartitionWithKey
+  :: (k -> v -> Bool) -> AssocList k v -> (AssocList k v, AssocList k v)
+alPartitionWithKey f al =
+  let (ys, ns) = List.partition (uncurry f) $ unAssocList al in
+    (AssocList ys, AssocList ns)
 
 alFilterWithKey :: (k -> b -> Bool) -> AssocList k b -> AssocList k b
 alFilterWithKey f = AssocList . filter (uncurry f) . unAssocList

--- a/src/Clapi/Types/Definitions.hs
+++ b/src/Clapi/Types/Definitions.hs
@@ -26,7 +26,9 @@ class OfMetaType metaType where
 
 data PostDefinition = PostDefinition
   { postDefDoc :: Text
-  , postDefArgs :: AssocList Seg TreeType
+  -- FIXME: We really need to stop treating single values as lists of types,
+  -- which makes the "top level" special:
+  , postDefArgs :: AssocList Seg [TreeType]
   } deriving (Show, Eq)
 
 data TupleDefinition = TupleDefinition

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -57,7 +57,9 @@ type DataDigest = AssocList Path DataChange
 
 data CreateOp
   = OpCreate
-  { ocArgs :: [WireValue]
+  -- FIXME: Nested lists of WireValues is a legacy hangover because our tree
+  -- data nodes still contain [WireValue] as a single "value":
+  { ocArgs :: [[WireValue]]
   , ocAfter :: Maybe (Either Placeholder Seg)
   } deriving (Show, Eq)
 type Creates = Map Path (Map Placeholder (Maybe Attributee, CreateOp))

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -1,28 +1,41 @@
+{-# LANGUAGE
+    LambdaCase
+#-}
+
 module Clapi.Types.Digests where
 
+import Data.Either (partitionEithers)
 import Data.Foldable (foldl')
-import Data.Maybe (fromJust)
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe (mapMaybe)
+import Data.Monoid
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Monoid
 import Data.Tagged (Tagged(..))
 import Data.Text (Text)
 import Data.Word (Word32)
 
+import qualified Data.Map.Mol as Mol
+
 import Clapi.Types.AssocList
-  (AssocList, alNull, alEmpty, alFromList, alFmapWithKey, alValues, alKeysSet)
+  (AssocList, alNull, alEmpty, alFromList, alFmapWithKey, alValues)
 import Clapi.Types.Base (Attributee, Time, Interpolation)
 import Clapi.Types.Definitions (Definition, Liberty, PostDefinition)
 import Clapi.Types.Messages
 import Clapi.Types.Path
-  ( Seg, Path, TypeName(..), tTnNamespace, pattern (:</), pattern (:/)
-  , Namespace(..))
+  ( Seg, Path, TypeName(..), pattern (:</), pattern (:/), Namespace(..)
+  , Placeholder(..))
+import qualified Clapi.Types.Path as Path
 import Clapi.Types.SequenceOps (SequenceOp(..), isSoAbsent)
 import Clapi.Types.Wire (WireValue)
 
 data SubOp = OpSubscribe | OpUnsubscribe deriving (Show, Eq)
+
+isSub :: SubOp -> Bool
+isSub OpSubscribe = True
+isSub OpUnsubscribe = False
+
 data DefOp def = OpDefine {odDef :: def} | OpUndefine deriving (Show, Eq)
 
 isUndef :: DefOp a -> Bool
@@ -42,8 +55,17 @@ data DataChange
   deriving (Show, Eq)
 type DataDigest = AssocList Path DataChange
 
-type ContainerOps args
-  = Map Path (Map Seg (Maybe Attributee, SequenceOp Seg args))
+data CreateOp
+  = OpCreate
+  { ocArgs :: [WireValue]
+  , ocAfter :: Maybe (Either Placeholder Seg)
+  } deriving (Show, Eq)
+type Creates = Map Path (Map Placeholder (Maybe Attributee, CreateOp))
+
+type RootContOps = Map Seg (SequenceOp Seg)
+-- FIXME: might this be better as Map (Path, Seg) (blah)? We spend a lot of time
+-- coping with the nested map-ness:
+type ContOps after = Map Path (Map Seg (Maybe Attributee, SequenceOp after))
 
 data PostOp
   = OpPost {opPath :: Path, opArgs :: Map Seg WireValue} deriving (Show, Eq)
@@ -53,8 +75,8 @@ data TrpDigest = TrpDigest
   , trpdPostDefs :: Map (Tagged PostDefinition Seg) (DefOp PostDefinition)
   , trpdDefinitions :: Map (Tagged Definition Seg) (DefOp Definition)
   , trpdData :: DataDigest
-  , trpdContainerOps :: ContainerOps ()
-  , trpdErrors :: Map (ErrorIndex Seg) [Text]
+  , trpdContOps :: ContOps Seg
+  , trpdErrors :: Map DataErrorIndex [Text]
   } deriving (Show, Eq)
 
 trpDigest :: Namespace -> TrpDigest
@@ -63,7 +85,7 @@ trpDigest ns = TrpDigest ns mempty mempty alEmpty mempty mempty
 trpdRemovedPaths :: TrpDigest -> [Path]
 trpdRemovedPaths trpd =
     ((unNamespace $ trpdNamespace trpd) :</) <$>
-    Map.foldlWithKey f [] (trpdContainerOps trpd)
+    Map.foldlWithKey f [] (trpdContOps trpd)
   where
     f acc p segMap = acc ++
       (fmap (p :/) $ Map.keys $ Map.filter isSoAbsent $ fmap snd segMap)
@@ -75,42 +97,82 @@ trpdNull (TrpDigest _ns postDefs defs dd cops errs) =
 data FrpDigest = FrpDigest
   { frpdNamespace :: Namespace
   , frpdData :: DataDigest
-  , frpdContainerOps :: ContainerOps [WireValue]
+  , frpdCreates :: Creates
+  , frpdContOps :: ContOps (Either Placeholder Seg)
   } deriving (Show, Eq)
 
 frpDigest :: Namespace -> FrpDigest
-frpDigest ns = FrpDigest ns alEmpty mempty
+frpDigest ns = FrpDigest ns mempty mempty mempty
 
-data FrpErrorDigest = FrpErrorDigest
-  { frpedErrors :: Map (ErrorIndex TypeName) [Text]
+frpdNull :: FrpDigest -> Bool
+frpdNull (FrpDigest _ dd creates cops) = null dd && null creates && null cops
+
+newtype FrpErrorDigest = FrpErrorDigest
+  { frpedErrors :: Map DataErrorIndex [Text]
   } deriving (Show, Eq)
 
-data TrcDigest = TrcDigest
-  { trcdPostTypeSubs :: Map (Tagged PostDefinition TypeName) SubOp
-  , trcdTypeSubs :: Map (Tagged Definition TypeName) SubOp
-  , trcdDataSubs :: Map Path SubOp
-  , trcdData :: DataDigest
-  , trcdContainerOps :: ContainerOps [WireValue]
+data TrcSubDigest = TrcSubDigest
+  { trcsdPostTypeSubs :: Map (Tagged PostDefinition TypeName) SubOp
+  , trcsdTypeSubs :: Map (Tagged Definition TypeName) SubOp
+  , trcsdDataSubs :: Map Path SubOp
   } deriving (Show, Eq)
 
-trcdEmpty :: TrcDigest
-trcdEmpty = TrcDigest mempty mempty mempty alEmpty mempty
+trcsdNamespaces :: TrcSubDigest -> Set Namespace
+trcsdNamespaces (TrcSubDigest ptSubs tSubs dSubs) =
+       -- Assumes TypeName ordered by Namespace first ;-)
+       Set.mapMonotonic (tnNamespace . unTagged) (Map.keysSet ptSubs)
+    <> Set.mapMonotonic (tnNamespace . unTagged) (Map.keysSet tSubs)
+       -- Assumes Path ordered in segment order
+    <> (Set.fromAscList
+        $ fmap (Namespace . fst)
+        $ mapMaybe Path.splitHead
+        $ Set.toAscList
+        $ Map.keysSet dSubs)
 
-data FrcDigest = FrcDigest
-  { frcdPostTypeUnsubs :: Set (Tagged PostDefinition TypeName)
-  , frcdTypeUnsubs :: Set (Tagged Definition TypeName)
-  , frcdDataUnsubs :: Set Path
-  , frcdPostDefs :: Map (Tagged PostDefinition TypeName) (DefOp PostDefinition)
-  , frcdDefinitions :: Map (Tagged Definition TypeName) (DefOp Definition)
-  , frcdTypeAssignments :: Map Path (Tagged Definition TypeName, Liberty)
-  , frcdData :: DataDigest
-  , frcdContainerOps :: ContainerOps ()
-  , frcdErrors :: Map (ErrorIndex TypeName) [Text]
+data TrcUpdateDigest = TrcUpdateDigest
+  { trcudNamespace :: Namespace
+  , trcudData :: DataDigest
+  , trcudCreates :: Creates
+  , trcudContOps :: ContOps (Either Placeholder Seg)
   } deriving (Show, Eq)
 
-frcdEmpty :: FrcDigest
-frcdEmpty = FrcDigest mempty mempty mempty mempty mempty mempty alEmpty mempty
-  mempty
+trcudEmpty :: Namespace -> TrcUpdateDigest
+trcudEmpty ns = TrcUpdateDigest ns mempty mempty mempty
+
+newtype FrcRootDigest = FrcRootDigest
+  { frcrdContOps :: RootContOps
+  } deriving (Show, Eq)
+
+data FrcSubDigest = FrcSubDigest
+  { frcsdErrors :: Map SubErrorIndex [Text]
+  , frcsdPostTypeUnusbs :: Set (Tagged PostDefinition TypeName)
+  , frcsdTypeUnusbs :: Set (Tagged Definition TypeName)
+  , frcsdDataUnusbs :: Set Path
+  } deriving (Show, Eq)
+
+frcsdNull :: FrcSubDigest -> Bool
+frcsdNull (FrcSubDigest errs ptUnsubs tUnsubs dUnsubs) =
+  null errs && null ptUnsubs && null tUnsubs && null dUnsubs
+
+frcsdEmpty :: FrcSubDigest
+frcsdEmpty = FrcSubDigest mempty mempty mempty mempty
+
+data FrcUpdateDigest = FrcUpdateDigest
+  { frcudNamespace :: Namespace
+  , frcudPostDefs :: Map (Tagged PostDefinition Seg) (DefOp PostDefinition)
+  , frcudDefinitions :: Map (Tagged Definition Seg) (DefOp Definition)
+  , frcudTypeAssignments :: Map Path (Tagged Definition TypeName, Liberty)
+  , frcudData :: DataDigest
+  , frcudContOps :: ContOps Seg
+  , frcudErrors :: Map DataErrorIndex [Text]
+  } deriving (Show, Eq)
+
+frcudEmpty :: Namespace -> FrcUpdateDigest
+frcudEmpty ns = FrcUpdateDigest ns mempty mempty mempty alEmpty mempty mempty
+
+frcudNull :: FrcUpdateDigest -> Bool
+frcudNull (FrcUpdateDigest _ postDefs defs tas dd cops errs) =
+  null postDefs && null defs && null tas && null dd && null cops && null errs
 
 newtype TrprDigest
   = TrprDigest {trprdNamespace :: Namespace}
@@ -119,31 +181,17 @@ newtype TrprDigest
 data TrDigest
   = Trpd TrpDigest
   | Trprd TrprDigest
-  | Trcd TrcDigest
+  | Trcsd TrcSubDigest
+  | Trcud TrcUpdateDigest
   deriving (Show, Eq)
 
 data FrDigest
   = Frpd FrpDigest
   | Frped FrpErrorDigest
-  | Frcd FrcDigest
+  | Frcrd FrcRootDigest
+  | Frcsd FrcSubDigest
+  | Frcud FrcUpdateDigest
   deriving (Show, Eq)
-
-trcdNamespaces :: TrcDigest -> Set Namespace
-trcdNamespaces (TrcDigest pts ts ds dd co) =
-    (Set.map tTnNamespace $ Map.keysSet pts)
-    <> (Set.map tTnNamespace $ Map.keysSet ts)
-    <> pathKeyNss (Map.keysSet ds)
-    <> pathKeyNss (alKeysSet dd) <> pathKeyNss (Map.keysSet co)
-  where
-    pathKeyNss = onlyJusts . Set.map pNs
-    onlyJusts = Set.map fromJust . Set.delete Nothing
-    pNs (ns :</ _) = Just $ Namespace ns
-    pNs _ = Nothing
-
-frcdNull :: FrcDigest -> Bool
-frcdNull (FrcDigest pTyUns tyUns datUns postDefs defs tas dd cops errs) =
-  null pTyUns && null tyUns && null datUns && null postDefs && null defs
-  && null tas && null dd && null cops && null errs
 
 -- | "Split" because kinda like :: Map k1 a -> Map k2 (Map k3 a)
 splitMap :: (Ord a, Ord b) => [(a, (b, c))] -> Map a (Map b c)
@@ -172,21 +220,70 @@ produceDataUpdateMessages = mconcat . alValues . alFmapWithKey procDc
         OpSet t wvs i -> MsgSet p tpid t wvs i att
         OpRemove -> MsgRemove p tpid att) : msgs) [] m
 
-digestContOpMessages :: [ContainerUpdateMessage args] -> ContainerOps argsg
-digestContOpMessages = splitMap . fmap procMsg
-  where
-    procMsg msg = case msg of
-      MsgMoveAfter p targ ref att -> (p, (targ, (att, SoMoveAfter ref)))
-      MsgAbsent p targ att -> (p, (targ, (att, SoAbsent)))
+unwrapTccum
+  :: ToClientContainerUpdateMessage
+  -> (Seg, (Maybe Attributee, SequenceOp Seg))
+unwrapTccum = \case
+  TccumPresentAfter targ ref att -> (targ, (att, SoAfter ref))
+  TccumAbsent targ att -> (targ, (att, SoAbsent))
 
-produceContOpMessages :: ContainerOps args -> [ContainerUpdateMessage args]
-produceContOpMessages = mconcat . Map.elems . Map.mapWithKey
-    (\p -> Map.elems . Map.mapWithKey (procCo p))
-  where
-    procCo p targ (att, co) = case co of
-      SoMoveAfter ref -> MsgMoveAfter p targ ref att
-      SoAbsent -> MsgAbsent p targ att
+toTccum
+  :: (Seg, (Maybe Attributee, SequenceOp Seg))
+  -> ToClientContainerUpdateMessage
+toTccum (targ, (att, so)) = case so of
+  SoAfter ref -> TccumPresentAfter targ ref att
+  SoAbsent -> TccumAbsent targ att
 
+digestRootContOpMsgs :: [ToClientContainerUpdateMessage] -> RootContOps
+digestRootContOpMsgs = fmap snd . Map.fromList . fmap unwrapTccum
+
+produceRootContOpMsgs :: RootContOps -> [ToClientContainerUpdateMessage]
+produceRootContOpMsgs = fmap toTccum . Map.toList . fmap (Nothing,)
+
+digestTccums :: [(Path, ToClientContainerUpdateMessage)] -> ContOps Seg
+digestTccums = splitMap . fmap (fmap unwrapTccum)
+
+produceTccums :: ContOps Seg -> [(Path, ToClientContainerUpdateMessage)]
+produceTccums = mconcat . Map.elems . Map.mapWithKey
+    (\p -> Map.elems . Map.mapWithKey (\t x -> (p, toTccum (t, x))))
+
+digestTpcums
+  :: [(Path, ToProviderContainerUpdateMessage)]
+  -> (Creates, ContOps (Either Placeholder Seg))
+digestTpcums msgs =
+  let
+    cs :: [(Path, (Placeholder, (Maybe Attributee, CreateOp)))]
+    xs :: [(Path, (Seg, (Maybe Attributee, SequenceOp (Either Placeholder Seg))))]
+    (cs, xs) = partitionEithers $ fmap (f . fmap procTpcum) msgs in
+    (mash cs, mash xs)
+  where
+    f :: (a, Either b c) -> Either (a, b) (a, c)
+    f (a, e) = either (Left . (a,)) (Right . (a,)) e
+    mash :: (Ord k1, Ord k2) => [(k1, (k2, v))] -> Map k1 (Map k2 v)
+    mash = fmap Map.fromList . Mol.fromList
+    procTpcum
+      :: ToProviderContainerUpdateMessage
+      -> Either
+           (Placeholder, (Maybe Attributee, CreateOp))
+           (Seg, (Maybe Attributee, SequenceOp (Either Placeholder Seg)))
+    procTpcum t = case t of
+      TpcumCreateAfter args ph ref att -> Left (ph, (att, OpCreate args ref))
+      TpcumMoveAfter targ ref att -> Right (targ, (att, SoAfter ref))
+      TpcumAbsent targ att -> Right (targ, (att, SoAbsent))
+
+
+produceTpcums
+  :: Creates -> ContOps (Either Placeholder Seg)
+  -> [(Path, ToProviderContainerUpdateMessage)]
+produceTpcums creates cops = createMsgs <> copMsgs
+  where
+    unmash f = Mol.toList . fmap (Map.elems . Map.mapWithKey f)
+    procCreate ph (att, OpCreate args ref) = TpcumCreateAfter args ph ref att
+    createMsgs = unmash procCreate creates
+    procCop targ (att, op) = case op of
+      SoAfter ref -> TpcumMoveAfter targ ref att
+      SoAbsent -> TpcumAbsent targ att
+    copMsgs = unmash procCop cops
 
 qualifyDefMessage :: Namespace -> DefMessage Seg def -> DefMessage TypeName def
 qualifyDefMessage ns dm = case dm of
@@ -252,20 +349,30 @@ produceTypeMessages
 produceTypeMessages = Map.elems . Map.mapWithKey
   (\p (tn, l) -> MsgAssignType p tn l)
 
-digestErrMessages :: Ord a => [MsgError a] -> Map (ErrorIndex a) [Text]
-digestErrMessages = foldl (Map.unionWith (<>)) mempty . fmap procMsg
+digestDataErrMsgs :: [DataErrorMessage] -> Map DataErrorIndex [Text]
+digestDataErrMsgs = foldl (Map.unionWith (<>)) mempty . fmap procMsg
   where
-    procMsg (MsgError ei t) = Map.singleton ei [t]
+    procMsg (MsgDataError ei t) = Map.singleton ei [t]
 
-produceErrMessages :: Map (ErrorIndex a) [Text] -> [MsgError a]
-produceErrMessages =
-  mconcat . Map.elems . Map.mapWithKey (\ei errs -> MsgError ei <$> errs)
+produceDataErrMsgs :: Map DataErrorIndex [Text] -> [DataErrorMessage]
+produceDataErrMsgs =
+  mconcat . Map.elems . Map.mapWithKey (\ei errs -> MsgDataError ei <$> errs)
+
+digestSubErrMsgs :: [SubErrorMessage] -> Map SubErrorIndex [Text]
+digestSubErrMsgs = foldl (Map.unionWith (<>)) mempty . fmap procMsg
+  where
+    procMsg (MsgSubError ei t) = Map.singleton ei [t]
+
+produceSubErrMsgs :: Map SubErrorIndex [Text] -> [SubErrorMessage]
+produceSubErrMsgs =
+  mconcat . Map.elems . Map.mapWithKey (\ei errs -> MsgSubError ei <$> errs)
 
 digestToRelayBundle :: ToRelayBundle -> TrDigest
 digestToRelayBundle trb = case trb of
     Trpb b -> Trpd $ digestToRelayProviderBundle b
     Trpr b -> Trprd $ digestToRelayProviderRelinquish b
-    Trcb b -> Trcd $ digestToRelayClientBundle b
+    Trcsb b -> Trcsd $ digestToRelayClientSubBundle b
+    Trcub b -> Trcud $ digestToRelayClientUpdateBundle b
   where
     digestToRelayProviderBundle :: ToRelayProviderBundle -> TrpDigest
     digestToRelayProviderBundle
@@ -274,162 +381,167 @@ digestToRelayBundle trb = case trb of
         (digestDefMessages postDefs)
         (digestDefMessages defs)
         (digestDataUpdateMessages dat)
-        (digestContOpMessages cont)
-        (digestErrMessages errs)
+        (digestTccums cont)
+        (digestDataErrMsgs errs)
 
     digestToRelayProviderRelinquish :: ToRelayProviderRelinquish -> TrprDigest
     digestToRelayProviderRelinquish (ToRelayProviderRelinquish ns) =
       TrprDigest ns
 
-    digestToRelayClientBundle :: ToRelayClientBundle -> TrcDigest
-    digestToRelayClientBundle (ToRelayClientBundle subs dat cont) =
+    digestToRelayClientSubBundle :: ToRelayClientSubBundle -> TrcSubDigest
+    digestToRelayClientSubBundle (ToRelayClientSubBundle subs) =
       let
         (postTySubs, tySubs, datSubs) = digestSubMessages subs
-        dd = digestDataUpdateMessages dat
-        co = digestContOpMessages cont
       in
-        TrcDigest postTySubs tySubs datSubs dd co
+        TrcSubDigest postTySubs tySubs datSubs
+
+    digestToRelayClientUpdateBundle
+      :: ToRelayClientUpdateBundle -> TrcUpdateDigest
+    digestToRelayClientUpdateBundle
+        (ToRelayClientUpdateBundle ns dat cont) =
+      let
+        dd = digestDataUpdateMessages dat
+        (creates, co) = digestTpcums cont
+      in
+        TrcUpdateDigest ns dd creates co
 
 produceToRelayBundle :: TrDigest -> ToRelayBundle
 produceToRelayBundle trd = case trd of
     Trpd d -> Trpb $ produceToRelayProviderBundle d
     Trprd d -> Trpr $ produceToRelayProviderRelinquish d
-    Trcd d -> Trcb $ produceToRelayClientBundle d
+    Trcsd d -> Trcsb $ produceToRelayClientSubBundle d
+    Trcud d -> Trcub $ produceToRelayClientUpdateBundle d
   where
     produceToRelayProviderBundle (TrpDigest ns postDefs defs dat cops errs) =
       ToRelayProviderBundle
-        ns (produceErrMessages errs)
+        ns (produceDataErrMsgs errs)
         (produceDefMessages postDefs) (produceDefMessages defs)
-        (produceDataUpdateMessages dat) (produceContOpMessages cops)
+        (produceDataUpdateMessages dat) (produceTccums cops)
 
     produceToRelayProviderRelinquish (TrprDigest ns) =
       ToRelayProviderRelinquish ns
 
-    produceToRelayClientBundle (TrcDigest pTySubs tySubs datSubs dd co) =
+    produceToRelayClientSubBundle (TrcSubDigest pTySubs tySubs datSubs) =
+      ToRelayClientSubBundle $ produceSubMessages pTySubs tySubs datSubs
+
+    produceToRelayClientUpdateBundle (TrcUpdateDigest ns dd creates co) =
       let
-        subs = produceSubMessages pTySubs tySubs datSubs
         dat = produceDataUpdateMessages dd
-        cont = produceContOpMessages co
+        cont = produceTpcums creates co
       in
-        ToRelayClientBundle subs dat cont
+        ToRelayClientUpdateBundle ns dat cont
 
 digestFromRelayBundle :: FromRelayBundle -> FrDigest
 digestFromRelayBundle frb = case frb of
     Frpb b -> Frpd $ digestFromRelayProviderBundle b
     Frpeb b -> Frped $ digestFromRelayProviderErrorBundle b
-    Frcb b -> Frcd $ digestFromRelayClientBundle b
+    Frcrb b -> Frcrd $ digestFromRelayClientRootBundle b
+    Frcsb b -> Frcsd $ digestFromRelayClientSubBundle b
+    Frcub b -> Frcud $ digestFromRelayClientUpdateBundle b
   where
     digestFromRelayProviderBundle (FromRelayProviderBundle ns dums coms) =
-        FrpDigest ns (digestDataUpdateMessages dums) (digestContOpMessages coms)
+      let
+        (creates, cops) = digestTpcums coms
+      in
+        FrpDigest ns (digestDataUpdateMessages dums) creates cops
 
     digestFromRelayProviderErrorBundle (FromRelayProviderErrorBundle errs) =
-        FrpErrorDigest $ digestErrMessages errs
+        FrpErrorDigest $ digestDataErrMsgs errs
 
-    digestFromRelayClientBundle
-        (FromRelayClientBundle ptSubs tSubs dSubs errs postDefs defs tas dums coms) =
-      FrcDigest
+    digestFromRelayClientRootBundle =
+      FrcRootDigest . digestRootContOpMsgs . frcrbContMsgs
+
+    digestFromRelayClientSubBundle
+        (FromRelayClientSubBundle subErrs ptSubs tSubs dSubs) =
+      FrcSubDigest
+        (digestSubErrMsgs subErrs)
         (Set.fromList ptSubs)
         (Set.fromList tSubs)
         (Set.fromList dSubs)
+
+    digestFromRelayClientUpdateBundle
+        (FromRelayClientUpdateBundle ns errs postDefs defs tas dums coms) =
+      FrcUpdateDigest ns
         (digestDefMessages postDefs)
         (digestDefMessages defs)
         (digestTypeMessages tas)
         (digestDataUpdateMessages dums)
-        (digestContOpMessages coms)
-        (digestErrMessages errs)
+        (digestTccums coms)
+        (digestDataErrMsgs errs)
 
 produceFromRelayBundle :: FrDigest -> FromRelayBundle
 produceFromRelayBundle frd = case frd of
     Frpd d -> Frpb $ produceFromRelayProviderBundle d
     Frped d -> Frpeb $ produceFromRelayProviderErrorBundle d
-    Frcd d -> Frcb $ produceFromRelayClientBundle d
+    Frcrd d -> Frcrb $ produceFromRelayClientRootBundle d
+    Frcsd d -> Frcsb $ produceFromRelayClientSubBundle d
+    Frcud d -> Frcub $ produceFromRelayClientUpdateBundle d
   where
     produceFromRelayProviderBundle :: FrpDigest -> FromRelayProviderBundle
-    produceFromRelayProviderBundle (FrpDigest ns dd co) =
+    produceFromRelayProviderBundle (FrpDigest ns dd creates co) =
       FromRelayProviderBundle ns
-      (produceDataUpdateMessages dd) (produceContOpMessages co)
+      (produceDataUpdateMessages dd) (produceTpcums creates co)
 
     produceFromRelayProviderErrorBundle
       :: FrpErrorDigest -> FromRelayProviderErrorBundle
     produceFromRelayProviderErrorBundle (FrpErrorDigest errs) =
-      FromRelayProviderErrorBundle $ produceErrMessages errs
+      FromRelayProviderErrorBundle $ produceDataErrMsgs errs
 
-    produceFromRelayClientBundle :: FrcDigest -> FromRelayClientBundle
-    produceFromRelayClientBundle
-        (FrcDigest postTyUns tyUns datUns postDefs defs tas dd co errs) =
-      FromRelayClientBundle
-        (Set.toList postTyUns) (Set.toList tyUns) (Set.toList datUns)
-        (produceErrMessages errs)
+    produceFromRelayClientRootBundle =
+      FromRelayClientRootBundle . produceRootContOpMsgs . frcrdContOps
+
+    produceFromRelayClientSubBundle :: FrcSubDigest -> FromRelayClientSubBundle
+    produceFromRelayClientSubBundle
+        (FrcSubDigest subErrs postTyUns tyUns datUns) =
+      FromRelayClientSubBundle
+        (produceSubErrMsgs subErrs)
+        (Set.toList postTyUns)
+        (Set.toList tyUns)
+        (Set.toList datUns)
+
+    produceFromRelayClientUpdateBundle
+      :: FrcUpdateDigest -> FromRelayClientUpdateBundle
+    produceFromRelayClientUpdateBundle
+        (FrcUpdateDigest ns postDefs defs tas dd co errs) =
+      FromRelayClientUpdateBundle ns
+        (produceDataErrMsgs errs)
         (produceDefMessages postDefs) (produceDefMessages defs)
         (produceTypeMessages tas)
-        (produceDataUpdateMessages dd) (produceContOpMessages co)
+        (produceDataUpdateMessages dd) (produceTccums co)
 
 -- The following are slightly different (and more internal to the relay), they
 -- are not neccessarily intended for a single recipient
 
-data InboundClientDigest = InboundClientDigest
-  { icdGets :: Set Path
-  , icdPostTypeGets :: Set (Tagged PostDefinition TypeName)
-  , icdTypeGets :: Set (Tagged Definition TypeName)
-  , icdContainerOps :: ContainerOps [WireValue]
-  , icdData :: DataDigest
-  } deriving (Show, Eq)
-
-inboundClientDigest :: InboundClientDigest
-inboundClientDigest = InboundClientDigest mempty mempty mempty mempty alEmpty
-
--- -- | This is basically a TrpDigest with the namespace expanded out
--- data InboundProviderDigest = InboundProviderDigest
---   { ipdContainerOps :: ContainerOps
---   , ipdDefinitions :: Map TypeName DefOp
---   , ipdData :: DataDigest
+-- data InboundClientDigest = InboundClientDigest
+--   { icdGets :: Set Path
+--   , icdPostTypeGets :: Set (Tagged PostDefinition TypeName)
+--   , icdTypeGets :: Set (Tagged Definition TypeName)
+--   , icdContOps :: ContOps [WireValue]
+--   , icdData :: DataDigest
 --   } deriving (Show, Eq)
 
--- qualifyTrpd :: TrpDigest -> InboundProviderDigest
--- qualifyTrpd (TrpDigest ns reords defs dd _) = InboundProviderDigest
---     (Map.mapKeys qualifyPath reords)
---     (Map.mapKeys (TypeName ns) defs)
---     (fromJust $ alMapKeys qualifyPath dd)
---   where
---     qualifyPath p = ns :</ p
+-- inboundClientDigest :: InboundClientDigest
+-- inboundClientDigest = InboundClientDigest mempty mempty mempty mempty
+--   alEmpty
 
-data InboundDigest
-  = Icd InboundClientDigest
-  | Ipd TrpDigest
-  | Iprd TrprDigest
-  deriving (Show, Eq)
+type OutboundClientUpdateDigest = FrcUpdateDigest
+type OutboundClientInitialisationDigest = OutboundClientUpdateDigest
+type OutboundClientSubErrsDigest = Map SubErrorIndex [Text]
+type OutboundProviderDigest = FrpDigest
 
-data OutboundClientDigest = OutboundClientDigest
-  { ocdContainerOps :: ContainerOps ()
-  , ocdPostDefs :: Map (Tagged PostDefinition TypeName) (DefOp PostDefinition)
-  , ocdDefinitions :: Map (Tagged Definition TypeName) (DefOp Definition)
-  , ocdTypeAssignments :: Map Path (Tagged Definition TypeName, Liberty)
-  , ocdData :: DataDigest
-  , ocdErrors :: Map (ErrorIndex TypeName) [Text]
-  } deriving (Show, Eq)
+-- data OutboundProviderDigest = OutboundProviderDigest
+--   { opdContainerOps :: ContainerOps [WireValue]
+--   , opdData :: DataDigest
+--   } deriving (Show, Eq)
 
-outboundClientDigest :: OutboundClientDigest
-outboundClientDigest = OutboundClientDigest mempty mempty mempty mempty alEmpty
-    mempty
-
-ocdNull :: OutboundClientDigest -> Bool
-ocdNull (OutboundClientDigest cops postDefs defs tas dd errs) =
-    null cops && null postDefs && null defs && null tas && alNull dd
-    && null errs
-
-type OutboundClientInitialisationDigest = OutboundClientDigest
-
-data OutboundProviderDigest = OutboundProviderDigest
-  { opdContainerOps :: ContainerOps [WireValue]
-  , opdData :: DataDigest
-  } deriving (Show, Eq)
-
-opdNull :: OutboundProviderDigest -> Bool
-opdNull (OutboundProviderDigest cops dd) = null cops && alNull dd
+-- opdNull :: OutboundProviderDigest -> Bool
+-- opdNull (OutboundProviderDigest cops dd) = null cops && alNull dd
 
 data OutboundDigest
   = Ocid OutboundClientInitialisationDigest
-  | Ocd OutboundClientDigest
+  | Ocsed OutboundClientSubErrsDigest
+  | Ocud OutboundClientUpdateDigest
+  | Ocrd FrcRootDigest
   | Opd OutboundProviderDigest
   | Ope FrpErrorDigest
   deriving (Show, Eq)

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -532,6 +532,9 @@ type OutboundClientInitialisationDigest = OutboundClientUpdateDigest
 type OutboundClientSubErrsDigest = Map SubErrorIndex [Text]
 type OutboundProviderDigest = FrpDigest
 
+ocsedNull :: OutboundClientSubErrsDigest -> Bool
+ocsedNull = null
+
 -- data OutboundProviderDigest = OutboundProviderDigest
 --   { opdContainerOps :: ContainerOps [WireValue]
 --   , opdData :: DataDigest
@@ -544,7 +547,6 @@ data OutboundDigest
   = Ocid OutboundClientInitialisationDigest
   | Ocsed OutboundClientSubErrsDigest
   | Ocud OutboundClientUpdateDigest
-  | Ocrd FrcRootDigest
   | Opd OutboundProviderDigest
   | Ope FrpErrorDigest
   deriving (Show, Eq)

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -517,18 +517,6 @@ produceFromRelayBundle frd = case frd of
 -- The following are slightly different (and more internal to the relay), they
 -- are not neccessarily intended for a single recipient
 
--- data InboundClientDigest = InboundClientDigest
---   { icdGets :: Set Path
---   , icdPostTypeGets :: Set (Tagged PostDefinition TypeName)
---   , icdTypeGets :: Set (Tagged Definition TypeName)
---   , icdContOps :: ContOps [WireValue]
---   , icdData :: DataDigest
---   } deriving (Show, Eq)
-
--- inboundClientDigest :: InboundClientDigest
--- inboundClientDigest = InboundClientDigest mempty mempty mempty mempty
---   alEmpty
-
 type OutboundClientUpdateDigest = FrcUpdateDigest
 type OutboundClientInitialisationDigest = OutboundClientUpdateDigest
 type OutboundClientSubErrsDigest = Map SubErrorIndex [Text]
@@ -536,14 +524,6 @@ type OutboundProviderDigest = FrpDigest
 
 ocsedNull :: OutboundClientSubErrsDigest -> Bool
 ocsedNull = null
-
--- data OutboundProviderDigest = OutboundProviderDigest
---   { opdContainerOps :: ContainerOps [WireValue]
---   , opdData :: DataDigest
---   } deriving (Show, Eq)
-
--- opdNull :: OutboundProviderDigest -> Bool
--- opdNull (OutboundProviderDigest cops dd) = null cops && alNull dd
 
 data OutboundDigest
   = Ocrid FrcRootDigest  -- "Outbound client root initialisation digest"

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -79,8 +79,8 @@ data TrpDigest = TrpDigest
   , trpdErrors :: Map DataErrorIndex [Text]
   } deriving (Show, Eq)
 
-trpDigest :: Namespace -> TrpDigest
-trpDigest ns = TrpDigest ns mempty mempty alEmpty mempty mempty
+trpdEmpty :: Namespace -> TrpDigest
+trpdEmpty ns = TrpDigest ns mempty mempty alEmpty mempty mempty
 
 trpdRemovedPaths :: TrpDigest -> [Path]
 trpdRemovedPaths trpd =
@@ -101,8 +101,8 @@ data FrpDigest = FrpDigest
   , frpdContOps :: ContOps (Either Placeholder Seg)
   } deriving (Show, Eq)
 
-frpDigest :: Namespace -> FrpDigest
-frpDigest ns = FrpDigest ns mempty mempty mempty
+frpdEmpty :: Namespace -> FrpDigest
+frpdEmpty ns = FrpDigest ns mempty mempty mempty
 
 frpdNull :: FrpDigest -> Bool
 frpdNull (FrpDigest _ dd creates cops) = null dd && null creates && null cops
@@ -116,6 +116,9 @@ data TrcSubDigest = TrcSubDigest
   , trcsdTypeSubs :: Map (Tagged Definition TypeName) SubOp
   , trcsdDataSubs :: Map Path SubOp
   } deriving (Show, Eq)
+
+trcsdEmpty :: TrcSubDigest
+trcsdEmpty = TrcSubDigest mempty mempty mempty
 
 trcsdNamespaces :: TrcSubDigest -> Set Namespace
 trcsdNamespaces (TrcSubDigest ptSubs tSubs dSubs) =
@@ -145,9 +148,9 @@ newtype FrcRootDigest = FrcRootDigest
 
 data FrcSubDigest = FrcSubDigest
   { frcsdErrors :: Map SubErrorIndex [Text]
-  , frcsdPostTypeUnusbs :: Set (Tagged PostDefinition TypeName)
-  , frcsdTypeUnusbs :: Set (Tagged Definition TypeName)
-  , frcsdDataUnusbs :: Set Path
+  , frcsdPostTypeUnsubs :: Set (Tagged PostDefinition TypeName)
+  , frcsdTypeUnsubs :: Set (Tagged Definition TypeName)
+  , frcsdDataUnsubs :: Set Path
   } deriving (Show, Eq)
 
 frcsdNull :: FrcSubDigest -> Bool

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -546,8 +546,10 @@ ocsedNull = null
 -- opdNull (OutboundProviderDigest cops dd) = null cops && alNull dd
 
 data OutboundDigest
-  = Ocid OutboundClientInitialisationDigest
+  = Ocrid FrcRootDigest  -- "Outbound client root initialisation digest"
+  | Ocid OutboundClientInitialisationDigest
   | Ocsed OutboundClientSubErrsDigest
+  | Ocrd FrcRootDigest
   | Ocud OutboundClientUpdateDigest
   | Opd OutboundProviderDigest
   | Ope FrpErrorDigest

--- a/src/Clapi/Types/Messages.hs
+++ b/src/Clapi/Types/Messages.hs
@@ -1,6 +1,5 @@
 module Clapi.Types.Messages where
 
-import Data.Bifunctor (bimap)
 import Data.Tagged (Tagged(..))
 import Data.Text (Text)
 import Data.Word (Word32)
@@ -8,45 +7,40 @@ import Data.Word (Word32)
 import Clapi.Types.Base (Attributee, Time, Interpolation)
 import Clapi.Types.Definitions (Definition, Liberty, PostDefinition)
 import Clapi.Types.Path
-  (Seg, Path, TypeName(..), qualify, unqualify, pattern (:</), Namespace(..))
-import qualified Clapi.Types.Path as Path
+  (Seg, Path, TypeName(..), Namespace(..), Placeholder(..))
 import Clapi.Types.Wire (WireValue)
 
 -- FIXME: redefinition
 type TpId = Word32
 
-data ErrorIndex a
+data DataErrorIndex
   = GlobalError
   | PathError Path
   | TimePointError Path TpId
-  | PostTypeError (Tagged PostDefinition a)
-  | TypeError (Tagged Definition a)
+  -- Placeholder errors need to go somewhere, but potentially not in the data
+  -- errs? Perhaps we should remove global errors too and make a bigger sum type
+  -- on top?!
+  -- | PlaceholderError Placeholder
   deriving (Show, Eq, Ord)
 
-splitErrIdx :: ErrorIndex TypeName -> Maybe (Namespace, ErrorIndex Seg)
-splitErrIdx ei = case ei of
-  GlobalError -> Nothing
-  PathError p -> bimap Namespace PathError <$> Path.splitHead p
-  TimePointError p tpid -> bimap Namespace (flip TimePointError tpid) <$>
-    Path.splitHead p
-  PostTypeError tn -> Just $ fmap PostTypeError $ unqualify tn
-  TypeError tn -> Just $ fmap TypeError $ unqualify tn
-
-namespaceErrIdx :: Namespace -> ErrorIndex Seg -> ErrorIndex TypeName
-namespaceErrIdx ns ei = case ei of
-  GlobalError -> GlobalError
-  PathError p -> PathError $ unNamespace ns :</ p
-  TimePointError p tpid -> TimePointError (unNamespace ns :</ p) tpid
-  PostTypeError s -> PostTypeError $ qualify ns s
-  TypeError s -> TypeError $ qualify ns s
-
-data MsgError a
-  = MsgError {errIndex :: ErrorIndex a, errMsgTxt :: Text} deriving (Eq, Show)
+data DataErrorMessage
+  = MsgDataError {dataErrIndex :: DataErrorIndex, dataErrTxt :: Text}
+  deriving (Eq, Show)
 
 data DefMessage ident def
   = MsgDefine ident def
   | MsgUndefine ident
   deriving (Show, Eq)
+
+data SubErrorIndex
+  = PostTypeSubError (Tagged PostDefinition TypeName)
+  | TypeSubError (Tagged Definition TypeName)
+  | PathSubError Path
+  deriving (Show, Eq, Ord)
+
+data SubErrorMessage
+  = MsgSubError {subErrIndex :: SubErrorIndex, subErrTxt :: Text}
+  deriving (Eq, Show)
 
 -- FIXME: might be nicer to break this up into sub and unsub values typed by
 -- what they are subscriptions for:
@@ -85,75 +79,102 @@ data DataUpdateMessage
       }
    deriving (Eq, Show)
 
-data ContainerUpdateMessage args
-  = MsgCreateAfter
-      { cuMsgPath :: Path
-      , cuMsgArgs :: args
-      , cuMsgPlaceholder :: Seg
-      , cuMsgRef :: Maybe Seg
-      , cuMsgAttributee :: Maybe Attributee
+data ToProviderContainerUpdateMessage
+  = TpcumCreateAfter
+      { tpcumArgs :: [WireValue]
+      , tpcumPlaceholder :: Placeholder
+      , tpcumRef :: Maybe (Either Placeholder Seg)
+      , tpcumAtt :: Maybe Attributee
       }
-  | MsgMoveAfter
-      { cuMsgPath :: Path
-      , cuMsgTarg :: Seg
-      , cuMsgRef :: Maybe Seg
-      , cuMsgAttributee :: Maybe Attributee
+  | TpcumMoveAfter
+      { tpcumTarg :: Seg
+      , tpcumRef :: Maybe (Either Placeholder Seg)
+      , tpcumAtt :: Maybe Attributee
       }
-  | MsgAbsent
-      { cuMsgPath :: Path
-      , cuMsgTarg :: Seg
-      , cuMsgAttributee :: Maybe Attributee
+  | TpcumAbsent
+      { tpcumTarg :: Seg
+      , tpcumAtt :: Maybe Attributee
+      }
+  deriving (Eq, Show)
+
+data ToClientContainerUpdateMessage
+  = TccumPresentAfter
+      { pcuMsgTarg :: Seg
+      , pcuMsgRef :: Maybe Seg
+      , pcuMsgAtt :: Maybe Attributee
+      }
+  | TccumAbsent
+      { pcuMsgTarg :: Seg
+      , pcuMsgAtt :: Maybe Attributee
       }
   deriving (Eq, Show)
 
 data ToRelayProviderBundle = ToRelayProviderBundle
   { trpbNamespace :: Namespace
-  , trpbErrors :: [MsgError Seg]
+  , trpbErrors :: [DataErrorMessage]
   , trpbPostDefs :: [DefMessage (Tagged PostDefinition Seg) PostDefinition]
   , trpbDefinitions :: [DefMessage (Tagged Definition Seg) Definition]
   , trpbData :: [DataUpdateMessage]
-  , trpbContMsgs :: [ContainerUpdateMessage ()]
+  , trpbContMsgs :: [(Path, ToClientContainerUpdateMessage)]
   } deriving (Show, Eq)
 
-data ToRelayProviderRelinquish
+newtype ToRelayProviderRelinquish
   = ToRelayProviderRelinquish Namespace deriving (Show, Eq)
 
 data FromRelayProviderBundle = FromRelayProviderBundle
   { frpbNamespace :: Namespace
   , frpbData :: [DataUpdateMessage]
-  , frpbContMsgs :: [ContainerUpdateMessage [WireValue]]
+  , frpbContMsgs :: [(Path, ToProviderContainerUpdateMessage)]
   } deriving (Show, Eq)
 
-data FromRelayProviderErrorBundle = FromRelayProviderErrorBundle
-  { frpebErrors :: [MsgError TypeName]
+newtype FromRelayProviderErrorBundle = FromRelayProviderErrorBundle
+  { frpebErrors :: [DataErrorMessage]
   } deriving (Eq, Show)
 
-data ToRelayClientBundle = ToRelayClientBundle
-  { trcbSubs :: [SubMessage]
+newtype ToRelayClientSubBundle = ToRelayClientSubBundle
+  -- FIXME: want to break this down so that we can no longer subscribe to root
+  -- (i.e. all subs are (Namespace, Path or Seg))
+  { trcsbSubs :: [SubMessage]
+  } deriving (Eq, Show)
+
+data ToRelayClientUpdateBundle = ToRelayClientUpdateBundle
+  { trcbNamespace :: Namespace
   , trcbData :: [DataUpdateMessage]
-  , trcbContMsgs :: [ContainerUpdateMessage [WireValue]]
+  , trcbContMsgs :: [(Path, ToProviderContainerUpdateMessage)]
   } deriving (Eq, Show)
 
-data FromRelayClientBundle = FromRelayClientBundle
-  { frcbPostTypeUnsubs :: [Tagged PostDefinition TypeName]
-  , frcbTypeUnsubs :: [Tagged Definition TypeName]
-  , frcbDataUnsubs :: [Path]
-  , frcbErrors :: [MsgError TypeName]
-  , frcbPostDefs :: [DefMessage (Tagged PostDefinition TypeName) PostDefinition]
-  , frcbDefinitions :: [DefMessage (Tagged Definition TypeName) Definition]
+newtype FromRelayClientRootBundle = FromRelayClientRootBundle
+  { frcrbContMsgs :: [ToClientContainerUpdateMessage]
+  } deriving (Eq, Show)
+
+data FromRelayClientSubBundle = FromRelayClientSubBundle
+  { frcsbSubErrs :: [SubErrorMessage]
+  , frcsbPostTypeUnsubs :: [Tagged PostDefinition TypeName]
+  , frcsbTypeUnsubs :: [Tagged Definition TypeName]
+  , frcsbDataUnsubs :: [Path]
+  } deriving (Eq, Show)
+
+data FromRelayClientUpdateBundle = FromRelayClientUpdateBundle
+  { frcbNamespace :: Namespace
+  , frcbErrors :: [DataErrorMessage]
+  , frcbPostDefs :: [DefMessage (Tagged PostDefinition Seg) PostDefinition]
+  , frcbDefinitions :: [DefMessage (Tagged Definition Seg) Definition]
   , frcbTypeAssignments :: [TypeMessage]
   , frcbData :: [DataUpdateMessage]
-  , frcbContMsgs :: [ContainerUpdateMessage ()]
+  , frcbContMsgs :: [(Path, ToClientContainerUpdateMessage)]
   } deriving (Show, Eq)
 
 data ToRelayBundle
   = Trpb ToRelayProviderBundle
   | Trpr ToRelayProviderRelinquish
-  | Trcb ToRelayClientBundle
+  | Trcsb ToRelayClientSubBundle
+  | Trcub ToRelayClientUpdateBundle
   deriving (Show, Eq)
 
 data FromRelayBundle
   = Frpb FromRelayProviderBundle
   | Frpeb FromRelayProviderErrorBundle
-  | Frcb FromRelayClientBundle
+  | Frcrb FromRelayClientRootBundle
+  | Frcsb FromRelayClientSubBundle
+  | Frcub FromRelayClientUpdateBundle
   deriving (Show, Eq)

--- a/src/Clapi/Types/Messages.hs
+++ b/src/Clapi/Types/Messages.hs
@@ -81,7 +81,9 @@ data DataUpdateMessage
 
 data ToProviderContainerUpdateMessage
   = TpcumCreateAfter
-      { tpcumArgs :: [WireValue]
+      -- FIXME: nested wire values is a legacy hangover because we still have
+      -- [WireValue] in tree data nodes representing single "values":
+      { tpcumArgs :: [[WireValue]]
       , tpcumPlaceholder :: Placeholder
       , tpcumRef :: Maybe (Either Placeholder Seg)
       , tpcumAtt :: Maybe Attributee

--- a/src/Clapi/Types/Path.hs
+++ b/src/Clapi/Types/Path.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE DeriveLift #-}
 
 module Clapi.Types.Path (
-    Path'(..), Path, Seg, mkSeg, unSeg,
+    Path'(..), Path, Seg, mkSeg, unSeg, Placeholder(..),
     pathP, segP, toText, fromText,
     splitHead, splitTail, parentPath,
     pattern Root, pattern (:</), pattern (:/),
@@ -113,7 +113,7 @@ data TypeName
   = TypeName {tnNamespace :: Namespace, tnName :: Seg} deriving (Eq, Ord)
 
 qualify :: Namespace -> Tagged a Seg -> Tagged a TypeName
-qualify ns (Tagged s) = Tagged $ TypeName ns s
+qualify ns taggedSeg = fmap (TypeName ns) taggedSeg
 
 unqualify :: Tagged a TypeName -> (Namespace, Tagged a Seg)
 unqualify (Tagged (TypeName ns s)) = (ns, Tagged s)
@@ -125,7 +125,7 @@ tTnNamespace :: Tagged a TypeName -> Namespace
 tTnNamespace = tnNamespace . unTagged
 
 tTnName :: Tagged a TypeName -> Tagged a Seg
-tTnName = Tagged . tnName . unTagged
+tTnName = fmap tnName
 
 qualSepChar :: Char
 qualSepChar = ':'

--- a/src/Clapi/Util.hs
+++ b/src/Clapi/Util.hs
@@ -11,6 +11,7 @@ module Clapi.Util (
     showItems,
     bound,
     safeToEnum,
+    nestMapsByKey,
     flattenNestedMaps, foldlNestedMaps,
     proxyF, proxyF3
 ) where
@@ -118,6 +119,17 @@ safeToEnum i =
   in if fromEnum theMin <= i && i <= fromEnum theMax
   then return r
   else fail "enum value out of range"
+
+nestMapsByKey
+  :: (Ord k, Ord k0, Ord k1)
+  => (k -> Maybe (k0, k1)) -> Map k a -> (Map k a, Map k0 (Map k1 a))
+nestMapsByKey f = Map.foldlWithKey g mempty
+  where
+    g (unsplit, nested) k val = case f k of
+      Just (k0, k1) ->
+        ( unsplit
+        , Map.alter (Just . Map.insert k1 val . maybe mempty id) k0 nested)
+      Nothing -> (Map.insert k val unsplit, nested)
 
 flattenNestedMaps
   :: (Ord k0, Ord k1, Ord k2)

--- a/src/Clapi/Util.hs
+++ b/src/Clapi/Util.hs
@@ -3,16 +3,12 @@
 #-}
 
 module Clapi.Util (
-    tagl, tagr,
-    append, (+|),
-    appendIfAbsent, (+|?),
     duplicates, ensureUnique,
     strictZipWith, strictZip, fmtStrictZipError,
     partitionDifference, partitionDifferenceF,
     camel,
     uncamel,
     showItems,
-    mkProxy,
     bound,
     safeToEnum,
     flattenNestedMaps, foldlNestedMaps,
@@ -33,24 +29,6 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Text.Printf (printf)
 
-
-tagl :: (a -> b) -> a -> (b, a)
-tagl f a = (f a, a)
-
-tagr :: (a -> b) -> a -> (a, b)
-tagr f a = (a, f a)
-
-append :: [a] -> a -> [a]
-append as a = as ++ [a]
-
-(+|) :: [a] -> a -> [a]
-(+|) = append
-
-appendIfAbsent :: (Eq a) => [a] -> a -> [a]
-appendIfAbsent as a | a `elem` as = as
-                    | otherwise = append as a
-(+|?) :: (Eq a) => [a] -> a -> [a]
-(+|?) = appendIfAbsent
 
 duplicates :: forall a. (Ord a) => [a] -> Set.Set a
 duplicates as = Map.keysSet $ Map.filter (>1) theMap
@@ -118,9 +96,6 @@ camel = (foldl (++) "") . (map initCap) . (splitOn "_") where
 
 showItems :: (Foldable f, Show a) => f a -> String
 showItems = intercalate ", " . fmap show . toList
-
-mkProxy :: a -> Proxy a
-mkProxy _ = Proxy
 
 bound :: forall a b m. (Enum a, Enum b, Bounded b, MonadFail m) => a -> m b
 bound i =

--- a/src/Clapi/Util.hs
+++ b/src/Clapi/Util.hs
@@ -11,6 +11,7 @@ module Clapi.Util (
     showItems,
     bound,
     safeToEnum,
+    mapPartitionEither,
     nestMapsByKey,
     flattenNestedMaps, foldlNestedMaps,
     proxyF, proxyF3
@@ -19,6 +20,7 @@ module Clapi.Util (
 import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail, fail)
 import Data.Char (isUpper, toLower, toUpper)
+import Data.Either (isLeft, fromLeft, fromRight)
 import Data.Foldable (Foldable, toList)
 import qualified Data.Foldable as Foldable
 import Data.List (intercalate)
@@ -143,6 +145,10 @@ foldlNestedMaps
 foldlNestedMaps f = Map.foldlWithKey g
   where
     g acc k0 = Map.foldlWithKey (\acc' k1 v -> f acc' k0 k1 v) acc
+
+mapPartitionEither :: Map k (Either a b) -> (Map k a, Map k b)
+mapPartitionEither m = let (ls, rs) = Map.partition isLeft m in
+  (fromLeft undefined <$> ls, fromRight undefined <$> rs)
 
 proxyF :: Proxy a -> Proxy b -> Proxy (a b)
 proxyF _ _ = Proxy

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -69,8 +69,6 @@ import Clapi.Types.Tree (TreeType(..), unbounded)
 import Clapi.Validator (validate, extractTypeAssertions)
 import qualified Clapi.Types.Dkmap as Dkmap
 
-import Debug.Trace
-
 -- FIXME: this should probably be `Map (Tagged def TypeName) def`
 type DefMap def = Map Namespace (Map (Tagged def Seg) def)
 type TypeAssignmentMap = Mos.Dependencies Path (Tagged Definition TypeName)
@@ -287,7 +285,7 @@ validateVs
        (Map DataErrorIndex [ValidationErr])
        (Map Path (Tagged Definition TypeName), Valuespace)
 validateVs t v = do
-    (newTypeAssns, refClaims, vs) <- inner mempty mempty (traceShow t t) v
+    (newTypeAssns, refClaims, vs) <- inner mempty mempty t v
     checkRefClaims (vsTyAssns vs) refClaims
     let (preExistingXrefs, newXrefs) = partitionXrefs (vsXrefs vs) refClaims
     let existingXrefErrs = validateExistingXrefs preExistingXrefs newTypeAssns

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -18,18 +18,17 @@ import Clapi.Types.Base (InterpolationLimit(..))
 import Clapi.Types.Definitions
   (arrayDef, structDef, tupleDef, Liberty(..))
 import Clapi.Types.Digests
-  ( DefOp(..), DataChange(..), TrpDigest(..), trpDigest
-  , InboundDigest(..), InboundClientDigest(..), OutboundDigest(..)
-  , OutboundClientDigest(..), outboundClientDigest, TrprDigest(..))
 import Clapi.Types.SequenceOps (SequenceOp(..))
-import Clapi.Types.Messages (ErrorIndex(..))
+import Clapi.Types.Messages (DataErrorIndex(..), SubErrorIndex(..))
 import Clapi.Types.Path
   (pattern Root, tTypeName, pattern (:/), pattern (:</), Namespace(..))
 import Clapi.Types.Tree (TreeType(..), unbounded)
 import Clapi.Types.Wire (WireValue(..))
 import Clapi.Valuespace
   ( baseValuespace, unsafeValidateVs, apiNs, Valuespace(..)
-  , rootTypeName, vsLookupDef)
+  , vsLookupDef)
+import Clapi.NamespaceTracker
+  ( PostNstInboundDigest(..), ClientGetDigest(..), cgdEmpty)
 
 spec :: Spec
 spec = describe "the relay protocol" $ do
@@ -38,7 +37,7 @@ spec = describe "the relay protocol" $ do
         fooDef = tupleDef "Some Word32"
           (alSingleton [segq|value|] (TtWord32 unbounded)) ILUninterpolated
         dd = alSingleton Root $ ConstChange bob [WireValue (42 :: Word32)]
-        inDig = Ipd $ (trpDigest $ Namespace foo)
+        inDig = PnidTrpd $ (trpdEmpty fooN)
           { trpdDefinitions = Map.singleton (Tagged foo) $ OpDefine fooDef
           , trpdData = dd
           }
@@ -46,18 +45,7 @@ spec = describe "the relay protocol" $ do
           [ (unNamespace apiNs, (tTypeName apiNs (unNamespace apiNs), Cannot))
           , (foo, (tTypeName (Namespace foo) foo, Cannot))
           ]
-        expectedOutDig = Ocd $ outboundClientDigest
-          { ocdData = qualify foo dd
-          , ocdDefinitions = Map.fromList
-            [ (tTypeName (Namespace foo) foo, OpDefine fooDef)
-            , (tTypeName apiNs [segq|root|], OpDefine extendedRootDef)
-            ]
-          , ocdTypeAssignments = Map.insert
-            [pathq|/foo|] (tTypeName (Namespace foo) foo, Cannot) mempty
-          , ocdContainerOps = Map.singleton Root $
-              Map.singleton foo
-              (Nothing, SoMoveAfter (Just $ unNamespace apiNs))
-          }
+        expectedOutDig = Ocrd $ FrcRootDigest $ Map.singleton foo $ SoAfter Nothing
         test = do
           sendFwd ((), inDig)
           waitThenRevOnly $ lift . (`shouldBe` expectedOutDig) . snd
@@ -72,53 +60,44 @@ spec = describe "the relay protocol" $ do
                  tupleDef "Thing" alEmpty ILUninterpolated) $
               vsTyDefs baseValuespace
           }
-        expectedOutDig = Ocd $ outboundClientDigest
-          { ocdDefinitions = Map.fromList
-            [ (rootTypeName, OpDefine $ fromJust $
-                vsLookupDef rootTypeName baseValuespace)
-            , (tTypeName (Namespace foo) foo, OpUndefine)
-            ]
-          , ocdContainerOps = Map.singleton Root $
-              Map.singleton foo (Nothing, SoAbsent)
-          }
+        expectedOutDig =
+          Ocrd $ FrcRootDigest $ Map.singleton foo SoAbsent
         test = do
-          sendFwd ((), Iprd $ TrprDigest $ Namespace foo)
+          sendFwd ((), PnidTrprd $ TrprDigest fooN)
           waitThenRevOnly $ lift . (`shouldBe` expectedOutDig) . snd
       in runEffect $ test <<-> relay vsWithStuff
     it "should reject subscriptions to non-existant paths" $
       let
         p = [pathq|/madeup|]
-        expectedOutDig = Ocid $ outboundClientDigest
-          { ocdErrors = Map.singleton (PathError p) ["Path not found"]
-          }
+        expectedOutDig = Ocsed $
+          Map.singleton (PathSubError p) ["Path not found"]
         test = do
-          sendFwd ((), Icd $
-            InboundClientDigest (Set.singleton p) mempty mempty mempty alEmpty)
+          sendFwd ((), PnidCgd $ cgdEmpty {cgdDataGets = Set.singleton p})
           waitThenRevOnly $ lift . (`shouldBe` expectedOutDig) . snd
       in runEffect $ test <<-> relay baseValuespace
     it "should have container ops for implicitly created children" $
       let
         kid = [segq|kid|]
         tyDefs = Map.fromList
-          [ (Tagged foo, arrayDef "arr" (tTypeName (Namespace foo) kid) Cannot)
+          [ ( Tagged foo
+            , arrayDef "arr" Nothing (tTypeName (Namespace foo) kid) Cannot)
           , (Tagged kid, tupleDef "kid" alEmpty ILUninterpolated)
           ]
         vsWithStuff = unsafeValidateVs $ baseValuespace
           { vsTree = treeInsert bob fooP (RtContainer alEmpty) $ vsTree baseValuespace
-          , vsTyDefs = Map.insert (Namespace foo) tyDefs $
+          , vsTyDefs = Map.insert fooN tyDefs $
                vsTyDefs baseValuespace
           }
         dd = alSingleton (Root :/ kid) $ ConstChange Nothing []
-        inDig = Ipd $ (trpDigest $ Namespace foo)
+        inDig = PnidTrpd $ (trpdEmpty fooN)
           { trpdData = dd
           }
-        qKid = fooP :/ kid
-        expectedOutDig = Ocd $ outboundClientDigest
-          { ocdData = qualify foo dd
-          , ocdTypeAssignments = Map.singleton qKid
-              (tTypeName (Namespace foo) kid, Cannot)
-          , ocdContainerOps = Map.singleton fooP $
-            Map.singleton kid (Nothing, SoMoveAfter Nothing)
+        expectedOutDig = Ocud $ (frcudEmpty fooN)
+          { frcudData = dd
+          , frcudTypeAssignments =
+              Map.singleton (Root :/ kid) (tTypeName fooN kid, Cannot)
+          , frcudContOps = Map.singleton Root $
+            Map.singleton kid (Nothing, SoAfter Nothing)
           }
         test = do
           sendFwd ((), inDig)
@@ -137,20 +116,22 @@ spec = describe "the relay protocol" $ do
           }
         dd = alSingleton Root $ ConstChange bob [WireValue (4 :: Word32)]
         test = do
-            sendFwd ((), Ipd $ (trpDigest $ Namespace foo) {trpdData = dd})
+            sendFwd ((), PnidTrpd $ (trpdEmpty fooN) {trpdData = dd})
             waitThenRevOnly $
-              lift . (`shouldBe` Ocd (outboundClientDigest {ocdData = qualify foo dd})) .
+              lift . (`shouldBe` (Ocud $ (frcudEmpty fooN) {frcudData = dd})) .
               snd
       in runEffect $ test <<-> relay vsWithInt
     it "should not send empty ocids/opds to client requests" $
       let
         test = do
-            sendFwd (1, Icd $ InboundClientDigest mempty mempty mempty mempty alEmpty)
-            sendFwd (2, Icd $ InboundClientDigest (Set.singleton [pathq|/whatevz|]) mempty mempty mempty alEmpty)
+            sendFwd (1, PnidCgd $ cgdEmpty)
+            sendFwd (2, PnidCgd $ cgdEmpty
+              {cgdDataGets = Set.singleton [pathq|/whatevz|]})
             waitThenRevOnly $ lift . (`shouldSatisfy` (== (2 :: Int)) . fst)
       in runEffect $ test <<-> relay baseValuespace
   where
     foo = [segq|foo|]
     fooP = Root :/ foo
+    fooN = Namespace foo
     bob = Just "bob"
     qualify ns = maybe (error "bad sneakers") id . alMapKeys (ns :</)

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -60,13 +60,15 @@ spec = describe "the relay protocol" $ do
                  tupleDef "Thing" alEmpty ILUninterpolated) $
               vsTyDefs baseValuespace
           }
-        expectedOutDig = Ocsed $
+        expectedOutDig1 = Ocrd $ FrcRootDigest $ Map.singleton foo SoAbsent
+        expectedOutDig2 = Ocsed $
           Map.singleton (PathSubError $ Root :/ foo) ["Path not found"]
         test = do
           sendFwd ((), PnidTrprd $ TrprDigest fooN)
           sendFwd ((), PnidCgd $
             cgdEmpty { cgdDataGets = Set.singleton fooP })
-          waitThenRevOnly $ lift . (`shouldBe` expectedOutDig) . snd
+          waitThenRevOnly $ lift . (`shouldBe` expectedOutDig1) . snd
+          waitThenRevOnly $ lift . (`shouldBe` expectedOutDig2) . snd
       in runEffect $ test <<-> relay vsWithStuff
     it "should reject subscriptions to non-existant paths" $
       let

--- a/test/SerialisationProtocolSpec.hs
+++ b/test/SerialisationProtocolSpec.hs
@@ -5,8 +5,7 @@ import Control.Monad (forever)
 import Control.Monad.Trans (lift)
 import qualified Data.ByteString as B
 
-import Clapi.Types (MsgError(..), ErrorIndex(..))
-import Clapi.Types.Path (Seg)
+import Clapi.Types (DataErrorMessage(..), DataErrorIndex(..))
 import Clapi.Protocol
   ((<<->), sendRev, sendFwd, waitThenFwdOnly, waitThenRevOnly, runEffect)
 import Clapi.Serialisation ()
@@ -16,8 +15,8 @@ spec :: Spec
 spec = it "Packetised round trip" $
     runEffect $ chunkyEcho <<-> serialiser <<-> test
   where
-    msg :: MsgError Seg
-    msg = MsgError GlobalError "part of test"
+    msg :: DataErrorMessage
+    msg = MsgDataError GlobalError "part of test"
     chunkyEcho = forever $ waitThenRevOnly $ \c ->
       let (c0, c1) = B.splitAt (B.length c `div` 2) c in
         sendFwd c0 >> sendFwd c1

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# LANGUAGE StandaloneDeriving, GeneralizedNewtypeDeriving #-}
 
 module SerialisationSpec where
 
@@ -99,7 +98,7 @@ instance Arbitrary DataUpdateMessage where
 
 instance Arbitrary ToProviderContainerUpdateMessage where
   arbitrary = oneof
-    [ TpcumCreateAfter <$> arbitrary <*> arbitrary
+    [ TpcumCreateAfter <$> smallListOf (smallListOf arbitrary) <*> arbitrary
       <*> arbitrary <*> arbitrary
     , TpcumMoveAfter <$> arbitrary <*> arbitrary <*> genAttributee
     , TpcumAbsent <$> arbitrary <*> genAttributee
@@ -151,7 +150,7 @@ instance Arbitrary FromRelayProviderErrorBundle where
   arbitrary = FromRelayProviderErrorBundle <$> smallListOf arbitrary
 
 instance Arbitrary ToRelayClientSubBundle where
-  arbitrary = ToRelayClientSubBundle <$> arbitrary
+  arbitrary = ToRelayClientSubBundle <$> smallListOf arbitrary
 
 instance Arbitrary ToRelayClientUpdateBundle where
   arbitrary = ToRelayClientUpdateBundle <$> arbitrary
@@ -178,7 +177,8 @@ instance Arbitrary FromRelayClientUpdateBundle where
     | (e', postDefs', defs', tas', dd', c')
     <- shrink (e, postDefs, defs, tas, dd, c)]
 
-deriving instance Arbitrary FromRelayClientRootBundle
+instance Arbitrary FromRelayClientRootBundle where
+    arbitrary = FromRelayClientRootBundle <$> smallListOf arbitrary
 
 instance Arbitrary ToRelayBundle where
   arbitrary = oneof

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE StandaloneDeriving, GeneralizedNewtypeDeriving #-}
 
 module SerialisationSpec where
 
@@ -17,17 +18,21 @@ import Data.Attoparsec.ByteString (parseOnly, endOfInput)
 import Clapi.Types
   ( Time, Attributee, WireValue
   , Interpolation(..), SubMessage(..), DataUpdateMessage(..), TypeMessage(..)
-  , MsgError(..), TpId, DefMessage(..)
-  , ContainerUpdateMessage(..)
-  , ToRelayClientBundle(..), ToRelayProviderBundle(..)
-  , FromRelayClientBundle(..), FromRelayProviderBundle(..)
+  , DataErrorMessage(..), TpId, DefMessage(..)
+  , ToClientContainerUpdateMessage(..)
+  , ToProviderContainerUpdateMessage(..)
+  , ToRelayClientSubBundle(..), ToRelayClientUpdateBundle(..)
+  , ToRelayProviderBundle(..)
+  , FromRelayClientRootBundle(..), FromRelayClientSubBundle(..)
+  , FromRelayClientUpdateBundle(..)
+  , FromRelayProviderBundle(..)
   , FromRelayProviderErrorBundle(..), ToRelayProviderRelinquish(..)
   , ToRelayBundle(..), FromRelayBundle(..)
-  , ErrorIndex(..))
+  , DataErrorIndex(..), SubErrorMessage(..), SubErrorIndex(..))
 import Clapi.Types.Path (Path, pattern Root)
 import Clapi.Serialisation (Encodable(..))
 
--- Incl. Arbitrary instances of WireValue:
+-- Incl. Arbitrary instances of WireValue, Namespace, Placeholder:
 import TypesSpec (smallListOf, arbitraryTextNoNull)
 
 encode :: (MonadFail m, Encodable a) => a -> m ByteString
@@ -92,26 +97,39 @@ instance Arbitrary DataUpdateMessage where
   shrink (MsgRemove p t a) = [MsgRemove p' t a' | (p', a') <- shrink (p, a)]
 
 
-instance Arbitrary args => Arbitrary (ContainerUpdateMessage args) where
+instance Arbitrary ToProviderContainerUpdateMessage where
   arbitrary = oneof
-    [ MsgCreateAfter <$> arbitrary <*> arbitrary <*> arbitrary
+    [ TpcumCreateAfter <$> arbitrary <*> arbitrary
       <*> arbitrary <*> arbitrary
-    , MsgMoveAfter <$> arbitrary <*> arbitrary <*> arbitrary <*> genAttributee
-    , MsgAbsent <$> arbitrary <*> arbitrary <*> genAttributee
+    , TpcumMoveAfter <$> arbitrary <*> arbitrary <*> genAttributee
+    , TpcumAbsent <$> arbitrary <*> genAttributee
     ]
 
-instance Arbitrary a => Arbitrary (ErrorIndex a) where
+instance Arbitrary ToClientContainerUpdateMessage where
+  arbitrary = oneof
+    [ TccumPresentAfter <$> arbitrary <*> arbitrary <*> genAttributee
+    , TccumAbsent <$> arbitrary <*> genAttributee
+    ]
+
+instance Arbitrary DataErrorIndex where
   arbitrary = oneof
     [ return GlobalError
     , PathError <$> arbitrary
     , TimePointError <$> arbitrary <*> arbitrary
-    , PostTypeError <$> arbitrary
-    , TypeError <$> arbitrary
     ]
 
-instance Arbitrary a => Arbitrary (MsgError a) where
-  arbitrary = MsgError <$> arbitrary <*> arbitraryTextNoNull
+instance Arbitrary SubErrorIndex where
+  arbitrary = oneof
+    [ PathSubError <$> arbitrary
+    , TypeSubError <$> arbitrary
+    , PostTypeSubError <$> arbitrary
+    ]
 
+instance Arbitrary DataErrorMessage where
+  arbitrary = MsgDataError <$> arbitrary <*> arbitraryTextNoNull
+
+instance Arbitrary SubErrorMessage where
+  arbitrary = MsgSubError <$> arbitrary <*> arbitraryTextNoNull
 
 instance Arbitrary ToRelayProviderBundle where
   arbitrary = ToRelayProviderBundle
@@ -132,43 +150,61 @@ instance Arbitrary ToRelayProviderRelinquish where
 instance Arbitrary FromRelayProviderErrorBundle where
   arbitrary = FromRelayProviderErrorBundle <$> smallListOf arbitrary
 
-instance Arbitrary ToRelayClientBundle where
-  arbitrary = ToRelayClientBundle <$> smallListOf arbitrary
-    <*> smallListOf arbitrary <*> smallListOf arbitrary
-  shrink (ToRelayClientBundle s d c) =
-    [ToRelayClientBundle s' d' c' | (s', d', c') <- shrink (s, d, c)]
+instance Arbitrary ToRelayClientSubBundle where
+  arbitrary = ToRelayClientSubBundle <$> arbitrary
 
-instance Arbitrary FromRelayClientBundle where
-  arbitrary = FromRelayClientBundle <$> smallListOf arbitrary
+instance Arbitrary ToRelayClientUpdateBundle where
+  arbitrary = ToRelayClientUpdateBundle <$> arbitrary
     <*> smallListOf arbitrary <*> smallListOf arbitrary
-    <*> smallListOf arbitrary <*> smallListOf arbitrary
-    <*> smallListOf arbitrary <*> smallListOf arbitrary
-    <*> smallListOf arbitrary <*> smallListOf arbitrary
-  shrink (FromRelayClientBundle ptu tu du e postDefs defs tas dd c) =
-    [FromRelayClientBundle ptu' tu' du' e' postDefs' defs' tas' dd' c'
-    | (ptu', tu', du', e', postDefs', defs', tas', dd', c')
-    <- shrink (ptu, tu, du, e, postDefs, defs, tas, dd, c)]
+  shrink (ToRelayClientUpdateBundle n d c) =
+    [ToRelayClientUpdateBundle n d' c' | (d', c') <- shrink (d, c)]
 
+instance Arbitrary FromRelayClientSubBundle where
+  arbitrary = FromRelayClientSubBundle
+    <$> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+  shrink (FromRelayClientSubBundle e ptu tu du) =
+    [FromRelayClientSubBundle e' ptu' tu' du'
+    | (e', ptu', tu', du')
+    <- shrink (e, ptu, tu, du)]
+
+instance Arbitrary FromRelayClientUpdateBundle where
+  arbitrary = FromRelayClientUpdateBundle <$> arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+    <*> smallListOf arbitrary <*> smallListOf arbitrary
+  shrink (FromRelayClientUpdateBundle ns e postDefs defs tas dd c) =
+    [FromRelayClientUpdateBundle ns e' postDefs' defs' tas' dd' c'
+    | (e', postDefs', defs', tas', dd', c')
+    <- shrink (e, postDefs, defs, tas, dd, c)]
+
+deriving instance Arbitrary FromRelayClientRootBundle
 
 instance Arbitrary ToRelayBundle where
   arbitrary = oneof
     [ Trpb <$> arbitrary
     , Trpr <$> arbitrary
-    , Trcb <$> arbitrary
+    , Trcsb <$> arbitrary
+    , Trcub <$> arbitrary
     ]
   shrink (Trpb b) = Trpb <$> shrink b
   shrink (Trpr b) = Trpr <$> shrink b
-  shrink (Trcb b) = Trcb <$> shrink b
+  shrink (Trcsb b) = Trcsb <$> shrink b
+  shrink (Trcub b) = Trcub <$> shrink b
 
 instance Arbitrary FromRelayBundle where
   arbitrary = oneof
     [ Frpb <$> arbitrary
     , Frpeb <$> arbitrary
-    , Frcb <$> arbitrary
+    , Frcrb <$> arbitrary
+    , Frcsb <$> arbitrary
+    , Frcub <$> arbitrary
     ]
   shrink (Frpb b) = Frpb <$> shrink b
   shrink (Frpeb b) = Frpeb <$> shrink b
-  shrink (Frcb b) = Frcb <$> shrink b
+  shrink (Frcrb b) = Frcrb <$> shrink b
+  shrink (Frcsb b) = Frcsb <$> shrink b
+  shrink (Frcub b) = Frcub <$> shrink b
 
 
 showBytes :: ByteString -> String

--- a/test/TypesSpec.hs
+++ b/test/TypesSpec.hs
@@ -31,11 +31,12 @@ import Clapi.Types
   ( Time(..), WireValue(..), WireType(..), Wireable, castWireValue, Liberty
   , InterpolationLimit, PostDefinition(..), Definition(..), StructDefinition(..)
   , TupleDefinition(..), ArrayDefinition(..), AssocList, alFromMap
-  , wireValueWireType, withWtProxy, Required)
+  , wireValueWireType, withWtProxy)
 import Clapi.Util (proxyF, proxyF3)
 
 import Clapi.Types.Tree (TreeType(..), Bounds, bounds, ttEnum)
-import Clapi.Types.Path (Seg, Path'(..), mkSeg, TypeName(..), Namespace(..))
+import Clapi.Types.Path
+  (Seg, Path'(..), mkSeg, TypeName(..), Namespace(..), Placeholder(..))
 import Clapi.Types.WireTH (mkWithWtProxy)
 
 smallListOf :: Gen a -> Gen [a]
@@ -65,9 +66,6 @@ instance Arbitrary TypeName where
   arbitrary = TypeName <$> arbitrary <*> arbitrary
 
 instance Arbitrary Liberty where
-    arbitrary = arbitraryBoundedEnum
-
-instance Arbitrary Required where
     arbitrary = arbitraryBoundedEnum
 
 instance Arbitrary InterpolationLimit where
@@ -169,7 +167,8 @@ instance Arbitrary Definition where
           , StructDef <$>
               (StructDefinition <$> arbitraryTextNoNull <*> arbitrary)
           , ArrayDef <$>
-              (ArrayDefinition <$> arbitraryTextNoNull <*> arbitrary <*> arbitrary)
+              (ArrayDefinition <$> arbitraryTextNoNull <*> arbitrary
+               <*> arbitrary <*> arbitrary)
           ]
 
 instance (Ord a, Random a, Arbitrary a) => Arbitrary (Bounds a) where
@@ -210,3 +209,4 @@ data TestEnum = TestOne | TestTwo | TestThree deriving (Show, Eq, Ord, Enum, Bou
 
 deriving instance Arbitrary a => Arbitrary (Tagged t a)
 deriving instance Arbitrary Namespace
+deriving instance Arbitrary Placeholder

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -133,7 +133,7 @@ spec = do
   describe "Validation" $ do
     it "baseValuespace valid" $
       let
-        allTainted = Map.fromList $ fmap (,Nothing) $ treePaths Root $
+        allTainted = Map.delete Root $ Map.fromList $ fmap (,Nothing) $ treePaths Root $
           vsTree baseValuespace
         validated = either (error . show) snd $
           validateVs allTainted baseValuespace
@@ -266,13 +266,13 @@ spec = do
     it "Relinquish" $
       let
         fs = [segq|foo|]
-        fooRootDef = arrayDef
-          "frd" Nothing (tTypeName apiNs [segq|version|]) Cannot
+        fooRootDef = structDef "frd" $
+          alSingleton fs (tTypeName apiNs [segq|version|], Cannot)
         claimFoo = TrpDigest
           (Namespace fs)
           mempty
           (Map.singleton (Tagged fs) $ OpDefine fooRootDef)
-          alEmpty
+          (alSingleton (Root :/ fs) $ ConstChange Nothing [WireValue @Word32 1, WireValue @Word32 1, WireValue @Int32 1])
           mempty
           mempty
       in do

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -23,17 +23,18 @@ import Clapi.Types.AssocList (AssocList, alSingleton, alEmpty, alInsert)
 import Clapi.Types
   ( InterpolationLimit(ILUninterpolated), WireValue(..)
   , TreeType(..), Liberty(..)
-  , tupleDef, structDef, arrayDef, ErrorIndex(..)
+  , tupleDef, structDef, arrayDef, DataErrorIndex(..)
   , Definition(..)
   , StructDefinition(strDefTypes)
-  , TrpDigest(..), DefOp(..), DataChange(..))
+  , TrpDigest(..), DefOp(..), DataChange(..)
+  , TrcUpdateDigest(..), trcudEmpty, frpdEmpty)
 import qualified Clapi.Types.Path as Path
 import Clapi.Types.Path
   ( Path, pattern (:/), pattern Root, Seg, TypeName(..), tTypeName
   , Namespace(..))
 import Clapi.Valuespace
   ( Valuespace(..), validateVs, baseValuespace, processToRelayProviderDigest
-  , processToRelayClientDigest, apiNs, vsRelinquish, ValidationErr(..))
+  , processTrcUpdateDigest, apiNs, vsRelinquish, ValidationErr(..))
 import Clapi.Tree (treePaths, updateTreeWithDigest)
 import Clapi.Types.SequenceOps (SequenceOp(..))
 import Clapi.Tree (RoseTreeNodeType(..))
@@ -123,7 +124,7 @@ emptyArrayD s vs = TrpDigest
     mempty
     mempty
   where
-    vaDef = arrayDef "for test" (tTypeName apiNs [segq|version|]) May
+    vaDef = arrayDef "for test" Nothing (tTypeName apiNs [segq|version|]) May
     -- FIXME: is vs always baseValuespace?
     rootDef = redefApiRoot (alInsert s $ tTypeName apiNs s) vs
 
@@ -265,7 +266,8 @@ spec = do
     it "Relinquish" $
       let
         fs = [segq|foo|]
-        fooRootDef = arrayDef "frd" (tTypeName apiNs [segq|version|]) Cannot
+        fooRootDef = arrayDef
+          "frd" Nothing (tTypeName apiNs [segq|version|]) Cannot
         claimFoo = TrpDigest
           (Namespace fs)
           mempty
@@ -279,8 +281,9 @@ spec = do
     describe "Client" $
         it "Can create new array entries" $
           let
-            dd = alSingleton [pathq|/api/arr/a|] $ ConstChange Nothing
+            dd = alSingleton [pathq|/arr/a|] $ ConstChange Nothing
                 [WireValue @Word32 1, WireValue @Word32 2, WireValue @Int32 3]
+            trcud = (trcudEmpty apiNs) {trcudData = dd}
           in do
             vs <- vsAppliesCleanly (emptyArrayD [segq|arr|] baseValuespace) baseValuespace
-            processToRelayClientDigest mempty dd vs `shouldBe` mempty
+            processTrcUpdateDigest vs trcud `shouldBe` (mempty, frpdEmpty apiNs)


### PR DESCRIPTION
Make client bundles/digests talk with namespaces. This (I think, as it's been a while!) made implementing creates easier as both the API provider and API client sides were then the same, so we avoided some horrible partitioning/combination.

Anyway, this is a massive mess of a PR because changes in structure kept begetting other changes in structure. The result isn't too nice, and has a lot of cruft left over, but _it works_ and hopefully if we get it in we can implementing further changes to tidy up some of the pieces given new constraints.

The headline is that :tada: creates should now actually work :tada: