### PR TITLE
Use VarWord encoding

### DIFF
--- a/clapi-hs.cabal
+++ b/clapi-hs.cabal
@@ -67,9 +67,11 @@ library
                      , async
                      , attoparsec
                      , attoparsec-binary
+                     , attoparsec-varword
                      , bimap
                      , blaze-builder
                      , bytestring
+                     , bytestring-builder-varword
                      , clock
                      , containers >= 0.5.8.1
                      , data-binary-ieee754

--- a/src/Clapi/Serialisation/Base.hs
+++ b/src/Clapi/Serialisation/Base.hs
@@ -51,9 +51,6 @@ instance Encodable Time where
     BVw.denseVarWordBe w64 <> BVw.denseVarWordBe w32
   parser = Time <$> AVw.denseVarWordBe <*> AVw.denseVarWordBe
 
-instance Encodable Word8 where
-  builder = return . fromWord8
-  parser = anyWord8
 instance Encodable Word32 where
   builder = return . BVw.denseVarWordBe
   parser = AVw.denseVarWordBe

--- a/src/Clapi/Serialisation/Base.hs
+++ b/src/Clapi/Serialisation/Base.hs
@@ -11,7 +11,6 @@ import Control.Monad.Fail (MonadFail(..))
 import Control.Monad (liftM2)
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Functor.Identity
 import Data.Tagged (Tagged(..))
 
 import Data.Word
@@ -82,10 +81,6 @@ instance Encodable Text where
       onError :: String -> Maybe Word8 -> Maybe Char
       onError _ Nothing = Nothing  -- Unexpected end of Input
       onError _ _ = Just '?'  -- Undecodable
-
-instance Encodable a => Encodable (Identity a) where
-  builder = builder . runIdentity
-  parser = Identity <$> parser
 
 deriving instance Encodable a => Encodable (Tagged t a)
 

--- a/src/Clapi/Serialisation/Wire.hs
+++ b/src/Clapi/Serialisation/Wire.hs
@@ -23,7 +23,7 @@ import Clapi.TH (btq)
 --   wire, so that we can define functions that we can verify are total.
 data WireTypeName
   = WtnTime
-  | WtnWord8 | WtnWord32 | WtnWord64
+  | WtnWord32 | WtnWord64
   | WtnInt32 | WtnInt64
   | WtnFloat | WtnDouble
   | WtnString
@@ -35,7 +35,6 @@ data WireTypeName
 wtName :: WireType -> WireTypeName
 wtName wt = case wt of
   WtTime -> WtnTime
-  WtWord8 -> WtnWord8
   WtWord32 -> WtnWord32
   WtWord64 -> WtnWord64
   WtInt32 -> WtnInt32
@@ -50,7 +49,6 @@ wtName wt = case wt of
 wtnTag :: WireTypeName -> Tag
 wtnTag wt = case wt of
   WtnTime -> [btq|t|]
-  WtnWord8 -> [btq|b|]
   WtnWord32 -> [btq|w|]
   WtnWord64 -> [btq|W|]
   WtnInt32 -> [btq|i|]
@@ -89,7 +87,6 @@ instance Encodable WireType where
       go :: WireTypeName -> Parser WireType
       go wtn = case wtn of
         WtnTime -> return WtTime
-        WtnWord8 -> return WtWord8
         WtnWord32 -> return WtWord32
         WtnWord64 -> return WtWord64
         WtnInt32 -> return WtInt32

--- a/src/Clapi/Types/TreeTypeProxy.hs
+++ b/src/Clapi/Types/TreeTypeProxy.hs
@@ -20,7 +20,7 @@ import Clapi.Types.Tree (TreeType(..))
 withTtProxy :: TreeType -> (forall a. Wireable a => Proxy a -> r) -> r
 withTtProxy tt f = case tt of
     TtTime -> f $ Proxy @Time
-    TtEnum _ -> f $ Proxy @Word8
+    TtEnum _ -> f $ Proxy @Word32
     TtWord32 _ -> f $ Proxy @Word32
     TtWord64 _ -> f $ Proxy @Word64
     TtInt32 _ -> f $ Proxy @Int32

--- a/src/Clapi/Types/Wire.hs
+++ b/src/Clapi/Types/Wire.hs
@@ -40,7 +40,6 @@ cast' a =
 
 class (Typeable a, Show a, Eq a, Ord a, Encodable a) => Wireable a
 instance Wireable Time
-instance Wireable Word8
 instance Wireable Word32
 instance Wireable Word64
 instance Wireable Int32
@@ -75,7 +74,7 @@ mf <|*|> wv = mf <*> castWireValue wv
 
 data WireType
   = WtTime
-  | WtWord8 | WtWord32 | WtWord64
+  | WtWord32 | WtWord64
   | WtInt32 | WtInt64
   | WtFloat | WtDouble
   | WtString
@@ -91,7 +90,6 @@ wireValueWireType (WireValue a) = go $ typeOf a
   where
     go :: TypeRep -> WireType
     go tr | tc == f @Time = WtTime
-          | tc == f @Word8 = WtWord8
           | tc == f @Word32 = WtWord32
           | tc == f @Word64 = WtWord64
           | tc == f @Int32 = WtInt32

--- a/src/Clapi/Types/WireTH.hs
+++ b/src/Clapi/Types/WireTH.hs
@@ -38,7 +38,6 @@ mkWithWtProxy newFnName preds =
             [VarP wt, VarP f]
             (NormalB $ CaseE (VarE wt)
               [ simpleCase "Time"
-              , simpleCase "Word8"
               , simpleCase "Word32"
               , simpleCase "Word64"
               , simpleCase "Int32"

--- a/src/Clapi/Validator.hs
+++ b/src/Clapi/Validator.hs
@@ -6,7 +6,7 @@ import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
 import Control.Monad (void)
 import Data.Bifunctor (first)
-import Data.Word (Word8)
+import Data.Word (Word32)
 import Data.Monoid ((<>))
 import Data.Proxy
 import Data.Tagged (Tagged(..))
@@ -145,7 +145,7 @@ checkString r t = maybe
   (const $ return t)
   (Text.unpack t =~~ Text.unpack r :: Maybe ())
 
-checkEnum :: MonadFail m => [Seg] -> Word8 -> m Word8
+checkEnum :: MonadFail m => [Seg] -> Word32 -> m Word32
 checkEnum ns w = let theMax = fromIntegral $ length ns in
   if w >= theMax
     then fail $ printf "Enum value %v out of range" w

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,7 +42,6 @@ packages:
 extra-deps:
   - attoparsec-binary-0.2
   - containers-0.5.8.1
-  - pipes-network-0.6.4.1
   - unagi-chan-0.4.0.0
 
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,8 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - attoparsec-binary-0.2
+  - attoparsec-varword-0.1.0.0
+  - bytestring-builder-varword-0.1.0.0
   - containers-0.5.8.1
   - unagi-chan-0.4.0.0
 

--- a/test/TypesSpec.hs
+++ b/test/TypesSpec.hs
@@ -105,7 +105,7 @@ instance (PickyArbitrary a, PickyArbitrary b) => PickyArbitrary (a, b)
 instance Arbitrary WireType where
   arbitrary = oneof
     [ return WtTime
-    , return WtWord8, return WtWord32, return WtWord64
+    , return WtWord32, return WtWord64
     , return WtInt32, return WtInt64
     , return WtFloat, return WtDouble
     , return WtString

--- a/test/ValidatorSpec.hs
+++ b/test/ValidatorSpec.hs
@@ -27,8 +27,8 @@ spec = describe "validation" $ do
     successCase (WireValue $ Time 2 3)
     failureCase (WireValue @Int32 3)
   describeTreeType (ttEnum $ Proxy @TestEnum) $ do
-    successCase (WireValue @Word8 2)
-    failureCase (WireValue @Word8 3)
+    successCase (WireValue @Word32 2)
+    failureCase (WireValue @Word32 3)
   describe "example bounded numbers" $ do
     bs0 <- either fail return $ bounds Nothing (Just 12)
     describeTreeType (TtInt32 bs0) $ do


### PR DESCRIPTION
Addresses #107.

We elected not to try to length-prefix strings/text, because encoding within the builder paradigm becomes quite hard.