### PR TITLE
Remove unnecessary containers constraint from stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -43,7 +43,6 @@ extra-deps:
   - attoparsec-binary-0.2
   - attoparsec-varword-0.1.0.0
   - bytestring-builder-varword-0.1.0.0
-  - containers-0.5.11.0
   - unagi-chan-0.4.0.0
   - multiset-0.3.4
 


### PR DESCRIPTION
We used to need a slightly in-the-future version I think, but now we've updated
the resolver we get one with what we need.