### PR TITLE
Fix erroneous errors

### DIFF
--- a/src/Clapi/Serialisation/Base.hs
+++ b/src/Clapi/Serialisation/Base.hs
@@ -163,7 +163,7 @@ tdTaggedParser td p = let at = tdAllTags td in do
       else fail $ "Invalid tag " ++ show t ++ " valid tags are " ++ show at
 
 tdTaggedBuilder
-  :: MonadFail m =>TaggedData e a -> (a -> m Builder) -> a -> m Builder
+  :: MonadFail m => TaggedData e a -> (a -> m Builder) -> a -> m Builder
 tdTaggedBuilder td bdr a = builder (tdInstanceToTag td $ a) <<>> bdr a
 
 

--- a/src/Clapi/Serialisation/Base.hs
+++ b/src/Clapi/Serialisation/Base.hs
@@ -19,6 +19,7 @@ import Data.Word
 import Data.Int
 import Data.Text (Text)
 
+import Data.Map.Mol (Mol(..))
 import Data.Map.Mos (Mos)
 import qualified Data.Map.Mos as Mos
 
@@ -108,6 +109,8 @@ instance (Encodable a, Ord a, Show a) => Encodable (UniqList a) where
 instance (Ord k, Encodable k, Encodable v) => Encodable (Map k v) where
   builder = builder . Map.toList
   parser = Map.fromList <$> parser
+
+deriving instance (Ord k, Encodable k, Encodable v) => Encodable (Mol k v)
 
 
 instance (Ord a, Encodable a) => Encodable (Set a) where

--- a/src/Clapi/Types/Digests.hs
+++ b/src/Clapi/Types/Digests.hs
@@ -15,6 +15,7 @@ import Data.Tagged (Tagged(..))
 import Data.Text (Text)
 import Data.Word (Word32)
 
+import Data.Map.Mol (Mol)
 import Data.Map.Mos (Mos)
 import qualified Data.Map.Mos as Mos
 
@@ -102,7 +103,7 @@ data TrpDigest = TrpDigest
   -- FIXME: should errors come in a different digest to data updates? At the
   -- moment we just check a TrpDigest isn't null when processing namespace
   -- claims...
-  , trpdErrors :: Map DataErrorIndex [Text]
+  , trpdErrors :: Mol DataErrorIndex Text
   } deriving (Show, Eq)
 
 trpdEmpty :: Namespace -> TrpDigest
@@ -133,7 +134,7 @@ frpdNull :: FrpDigest -> Bool
 frpdNull (FrpDigest _ dd creates cops) = null dd && null creates && null cops
 
 newtype FrpErrorDigest = FrpErrorDigest
-  { frpedErrors :: Map DataErrorIndex [Text]
+  { frpedErrors :: Mol DataErrorIndex Text
   } deriving (Show, Eq)
 
 frpedNull :: FrpErrorDigest -> Bool
@@ -256,7 +257,7 @@ data FrcUpdateDigest = FrcUpdateDigest
   , frcudTypeAssignments :: Map Path (Tagged Definition Seg, Editable)
   , frcudData :: DataDigest
   , frcudContOps :: ContOps Seg
-  , frcudErrors :: Map DataErrorIndex [Text]
+  , frcudErrors :: Mol DataErrorIndex Text
   } deriving (Show, Eq)
 
 frcudEmpty :: Namespace -> FrcUpdateDigest

--- a/src/Data/Map/Mol.hs
+++ b/src/Data/Map/Mol.hs
@@ -43,6 +43,12 @@ fromSet f = Mol . Map.fromSet (pure . f)
 keys :: Mol k a -> [k]
 keys = Map.keys . unMol
 
+keysSet :: Mol k a -> Set k
+keysSet = Map.keysSet . unMol
+
+lookup :: (Ord k) => k -> Mol k a -> [a]
+lookup k = maybe [] id . Map.lookup k . unMol
+
 cons :: (Ord k) => k -> a -> Mol k a -> Mol k a
 cons k a = Mol . Map.updateM (a :) k . unMol
 

--- a/src/Data/Map/Mol.hs
+++ b/src/Data/Map/Mol.hs
@@ -37,6 +37,10 @@ fromMap = Mol . Map.filter (not . null)
 
 fromSet :: (k -> a) -> Set k -> Mol k a
 fromSet f = Mol . Map.fromSet (pure . f)
+
+keys :: Mol k a -> [k]
+keys = Map.keys . unMol
+
 cons :: (Ord k) => k -> a -> Mol k a -> Mol k a
 cons k a = Mol . Map.updateM (a :) k . unMol
 
@@ -54,3 +58,12 @@ union (Mol m1) (Mol m2) = Mol $ Map.unionWith (<>) m1 m2
 
 unions :: (Ord k) => [Mol k a] -> Mol k a
 unions = Mol . Map.unionsWith (<>) . fmap unMol
+
+mapKeys :: Ord k2 => (k1 -> k2) -> Mol k1 a -> Mol k2 a
+mapKeys f = Mol . Map.mapKeys f . unMol
+
+mapKeysMonotonic :: (k1 -> k2) -> Mol k1 a -> Mol k2 a
+mapKeysMonotonic f = Mol . Map.mapKeysMonotonic f . unMol
+
+filterWithKey :: (k -> a -> Bool) -> Mol k a -> Mol k a
+filterWithKey p = fromMap . Map.mapWithKey (\k as -> filter (p k) as) . unMol

--- a/src/Data/Map/Mol.hs
+++ b/src/Data/Map/Mol.hs
@@ -21,10 +21,12 @@ instance Ord k => Monoid (Mol k a) where
   mempty = Mol mempty
 
 singleton :: k -> a -> Mol k a
-singleton k a = singletonList k [a]
+singleton k a = Mol $ Map.singleton k [a]
 
 singletonList :: k -> [a] -> Mol k a
-singletonList k as = Mol $ Map.singleton k as
+singletonList k as = Mol $ if null as
+  then Map.empty
+  else Map.singleton k as
 
 fromList :: (Ord k) => [(k, a)] -> Mol k a
 fromList = foldr (uncurry cons) mempty

--- a/src/Data/Map/Mol.hs
+++ b/src/Data/Map/Mol.hs
@@ -5,7 +5,9 @@
 #-}
 module Data.Map.Mol where
 
+import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Set (Set)
 
 import Data.Map.Clapi as Map
 
@@ -19,7 +21,10 @@ instance Ord k => Monoid (Mol k a) where
   mempty = Mol mempty
 
 singleton :: k -> a -> Mol k a
-singleton k a = Mol $ Map.singleton k [a]
+singleton k a = singletonList k [a]
+
+singletonList :: k -> [a] -> Mol k a
+singletonList k as = Mol $ Map.singleton k as
 
 fromList :: (Ord k) => [(k, a)] -> Mol k a
 fromList = foldr (uncurry cons) mempty
@@ -27,6 +32,11 @@ fromList = foldr (uncurry cons) mempty
 toList :: (Ord k) => Mol k a -> [(k, a)]
 toList (Mol m) = mconcat $ sequence <$> Map.toList m
 
+fromMap :: Map k [a] -> Mol k a
+fromMap = Mol . Map.filter (not . null)
+
+fromSet :: (k -> a) -> Set k -> Mol k a
+fromSet f = Mol . Map.fromSet (pure . f)
 cons :: (Ord k) => k -> a -> Mol k a -> Mol k a
 cons k a = Mol . Map.updateM (a :) k . unMol
 

--- a/test/SerialisationProtocolSpec.hs
+++ b/test/SerialisationProtocolSpec.hs
@@ -8,7 +8,8 @@ import Test.Hspec
 import Control.Monad (forever)
 import Control.Monad.Trans (lift)
 import qualified Data.ByteString as B
-import qualified Data.Map as Map
+
+import qualified Data.Map.Mol as Mol
 
 import Clapi.Types (FrDigest(..), FrpErrorDigest(..), DataErrorIndex(..))
 import Clapi.Protocol
@@ -21,7 +22,7 @@ spec = it "Packetised round trip" $
     runEffect $ chunkyEcho <<-> serialiser <<-> test
   where
     msg :: FrDigest
-    msg = Frped $ FrpErrorDigest $ Map.singleton GlobalError ["part of test"]
+    msg = Frped $ FrpErrorDigest $ Mol.singleton GlobalError "part of test"
     chunkyEcho = forever $ waitThenRevOnly $ \c ->
       let (c0, c1) = B.splitAt (B.length c `div` 2) c in
         sendFwd c0 >> sendFwd c1

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -18,6 +18,8 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Control.Monad.Fail (MonadFail)
 
+import qualified Data.Map.Mol as Mol
+
 import Clapi.TH
 import Clapi.Types.AssocList
   ( AssocList, alSingleton, alEmpty, alInsert, alFromList)
@@ -73,14 +75,14 @@ testValuespace = unsafeValidateVs $ (baseValuespace (Tagged testS) Editable)
 
 vsProviderErrorsOn :: Valuespace -> TrpDigest -> [Path] -> Expectation
 vsProviderErrorsOn vs d ps = case (processToRelayProviderDigest d vs) of
-    Left errMap -> Map.keysSet errMap `shouldBe` Set.fromList (PathError <$> ps)
+    Left errMap -> Mol.keysSet errMap `shouldBe` Set.fromList (PathError <$> ps)
     Right _ -> fail "Did not get expected errors"
 
 vsClientErrorsOn :: Valuespace -> TrcUpdateDigest -> [Path] -> Expectation
 vsClientErrorsOn vs d ps = let (errMap, _) = processTrcUpdateDigest vs d in
   if (null errMap)
     then fail "Did not get expected errors"
-    else Map.keysSet errMap `shouldBe` Set.fromList (PathError <$> ps)
+    else Mol.keysSet errMap `shouldBe` Set.fromList (PathError <$> ps)
 
 validVersionTypeChange :: Valuespace -> TrpDigest
 validVersionTypeChange vs =


### PR DESCRIPTION
This is an initial stab at tightening up our error handling in Clapi so that we don't send bizarre errors back to clients on creates. It probably won't fix the actual bug, but tightening up the type should add a little more control to the errors anyway as a good starting point.