### PR TITLE
Handle insertions into implicit nested structs gracefully

### DIFF
--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -278,11 +278,11 @@ validateVs t v = do
                               then Just (path :/ name, cts)
                               else Nothing
                         BadNodeType _ treeType ->
-                          case (treeType, path) of
-                            (RtntEmpty, Root) -> do
+                          case treeType of
+                            RtntEmpty -> do
                                 isEmpty <- isEmptyContainer mempty def
                                 if isEmpty
-                                  then Just (Root, ts)
+                                  then Just (path, ts)
                                   else Nothing
                             _ -> Nothing
                         _ -> Nothing

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -314,7 +314,16 @@ spec = do
             alEmpty
             mempty
             mempty
-      in void $ vsAppliesCleanly emptyNest $ baseValuespace (Tagged emptyS) Editable :: IO ()
+        addToNestedStruct = TrpDigest
+            (Namespace emptyS)
+            mempty
+            mempty
+            alEmpty
+            (Map.singleton [pathq|/arr|] $ Map.singleton emptyS (Nothing, SoAfter Nothing))
+            mempty
+      in do
+        vs <- vsAppliesCleanly emptyNest $ baseValuespace (Tagged emptyS) Editable
+        void $ vsAppliesCleanly addToNestedStruct vs :: IO ()
     it "Rejects recursive struct" $
       let
         rS = [segq|r|]


### PR DESCRIPTION
This case can happen at paths that aren't the root too.