### PR TITLE
Allow applying of contOps in digests declaring arrays

### DIFF
--- a/src/Clapi/Tree.hs
+++ b/src/Clapi/Tree.hs
@@ -84,6 +84,7 @@ treeApplyReorderings contOps (RtContainer children) =
   in
     RtContainer . alFmapWithKey reattribute . alPickFromMap childMap
     <$> (updateUniqList (snd <$> contOps) $ alKeys children)
+treeApplyReorderings contOps RtEmpty = treeApplyReorderings contOps (RtContainer alEmpty)
 treeApplyReorderings _ _ = fail "Not a container"
 
 treeConstSet :: Maybe Attributee -> a -> RoseTree a -> RoseTree a

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -324,6 +324,17 @@ spec = do
       in do
         vs <- vsAppliesCleanly emptyNest $ baseValuespace (Tagged emptyS) Editable
         void $ vsAppliesCleanly addToNestedStruct vs :: IO ()
+    it "Allows contops in array declaring digest" $
+      let
+        codS = [segq|cod|]
+        codb = TrpDigest
+            (Namespace codS)
+            mempty
+            (Map.singleton (Tagged codS) $ OpDefine $ arrayDef "fishy" Nothing (Tagged codS) ReadOnly)
+            alEmpty
+            (Map.singleton Root $ Map.singleton codS (Nothing, SoAfter Nothing))
+            mempty
+      in void $ vsAppliesCleanly codb $ baseValuespace (Tagged codS) Editable :: IO ()
     it "Rejects recursive struct" $
       let
         rS = [segq|r|]


### PR DESCRIPTION
I can't think of any obvious missing testing (although I have a nagging headache, so that's not exactly watertight).
If you can think of anything, yell.