### PR TITLE
Fix bugs around contOps

### DIFF
--- a/src/Clapi/Tree.hs
+++ b/src/Clapi/Tree.hs
@@ -77,9 +77,7 @@ treeApplyReorderings contOps (RtContainer children) =
   let
     attMap = fst <$> contOps
     childMap = Map.foldlWithKey'
-        (\acc k att -> if Map.notMember k acc
-            then Map.insert k (att, RtEmpty) acc
-            else acc)
+        (\acc k att -> Map.alter (Just . maybe (att, RtEmpty) id) k acc)
         (alToMap children)
         (fst <$> contOps)
     reattribute s (oldMa, rt) = (Map.findWithDefault oldMa s attMap, rt)

--- a/src/Clapi/Tree.hs
+++ b/src/Clapi/Tree.hs
@@ -77,7 +77,9 @@ treeApplyReorderings contOps (RtContainer children) =
   let
     attMap = fst <$> contOps
     childMap = Map.foldlWithKey'
-        (\acc k att -> Map.insert k (att, RtEmpty) acc)
+        (\acc k att -> if Map.notMember k acc
+            then Map.insert k (att, RtEmpty) acc
+            else acc)
         (alToMap children)
         (fst <$> contOps)
     reattribute s (oldMa, rt) = (Map.findWithDefault oldMa s attMap, rt)

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -248,7 +248,8 @@ validateVs t v = do
             -- counted as such.
             Nothing -> case path of
               (parentPath :/ _) -> inner
-                newTas newRefClaims (Map.insert parentPath Nothing tainted)
+                newTas newRefClaims
+                (Map.insert parentPath Nothing $ Map.delete path tainted)
                 vs
               _ -> Left $ Mol.singleton GlobalError $
                 GenericErr "Attempted to taint parent of root"

--- a/test/TreeSpec.hs
+++ b/test/TreeSpec.hs
@@ -5,14 +5,16 @@
 module TreeSpec where
 
 import Test.Hspec
+import qualified Data.Map as Map
 
 import Clapi.TH
 import Clapi.Types.AssocList (alSingleton, alFromList)
 import qualified Clapi.Types.Dkmap as Dkmap
 import Clapi.Types.Path (Seg, pattern Root, pattern (:/))
+import Clapi.Types.SequenceOps (SequenceOp(SoAfter))
 import Clapi.Tree
   ( RoseTree(..), RoseTreeNode(..), treePaths, treeLookup, treeInsert
-  , treeDelete, treeLookupNode)
+  , treeDelete, treeLookupNode, treeApplyReorderings)
 
 import Instances ()
 
@@ -89,3 +91,8 @@ spec = do
     it "doesn't create illegitimate parents" $ do
       treeDelete [pathq|/t3/to/box|] t3 `shouldBe` t3
       treeDelete [pathq|/t1/to/box|] t3 `shouldBe` t3
+
+  describe "treeApplyReorderings" $ do
+    it "should preserve child contents" $
+      treeApplyReorderings (Map.singleton s3 (Nothing, SoAfter Nothing)) t4
+      `shouldBe` (Right t4 :: Either String (RoseTree Char))

--- a/test/TypesSpec.hs
+++ b/test/TypesSpec.hs
@@ -14,9 +14,12 @@ import Test.QuickCheck (property)
 
 import Control.Monad.Fail (MonadFail)
 import Data.Proxy
+import qualified Data.Map as Map
 
 import Clapi.Types
-  (WireValue(..), Wireable, castWireValue, wireValueWireType, withWtProxy)
+  ( WireValue(..), Wireable, castWireValue, wireValueWireType, withWtProxy
+  , ulSingle)
+import Clapi.Types.SequenceOps (SequenceOp(..), updateUniqList)
 
 import Arbitrary ()
 
@@ -34,3 +37,8 @@ spec = do
   describe "WireValue" $ do
     it "should survive a round trip via a native Haskell value" $ property $
       either error id . roundTripWireValue
+  describe "SequenceOps" $ do
+    it "works on single no-op reordering" $
+      let
+        ul = ulSingle 'c'
+      in updateUniqList (Map.singleton 'c' $ SoAfter Nothing) ul `shouldBe` Just ul

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -255,7 +255,7 @@ spec = do
           vs'
         (vsAppliesCleanly (validVersionTypeChange vs'') vs''
           :: Either String Valuespace) `shouldSatisfy` isRight
-    it "Copes with contOps and set in same bundle" $
+    it "Copes with set and absent in same bundle" $
       let
         xS = [segq|cross|]
         aS = [segq|a|]

--- a/test/ValuespaceSpec.hs
+++ b/test/ValuespaceSpec.hs
@@ -255,44 +255,22 @@ spec = do
           vs'
         (vsAppliesCleanly (validVersionTypeChange vs'') vs''
           :: Either String Valuespace) `shouldSatisfy` isRight
-    it "copes with crossy xrefs" $
+    it "Copes with contOps and set in same bundle" $
       let
         xS = [segq|cross|]
         aS = [segq|a|]
-        asS = [segq|as|]
-        assS = [segq|ass|]
-        bS = [segq|b|]
-        bsS = [segq|bs|]
-        bssS = [segq|bss|]
         vs = baseValuespace (Tagged xS) Editable
         d = TrpDigest
             (Namespace xS)
             mempty
             (Map.fromList
-              [ (Tagged xS, OpDefine $ structDef "kriss" $ alFromList $ (\s -> (s, (Tagged s, ReadOnly))) <$> [assS, bssS])
-              , (Tagged assS, OpDefine $ arrayDef "arefss" Nothing (Tagged asS) ReadOnly)
-              , (Tagged asS, OpDefine $ arrayDef "arefs" Nothing (Tagged aS) ReadOnly)
-              , (Tagged aS, OpDefine $ tupleDef "ref a" (alSingleton aS $ TtRef bsS) ILUninterpolated)
-              , (Tagged bssS, OpDefine $ arrayDef "brefss" Nothing (Tagged bsS) ReadOnly)
-              , (Tagged bsS, OpDefine $ arrayDef "brefs" Nothing (Tagged bS) ReadOnly)
-              , (Tagged bS, OpDefine $ tupleDef "ref b" (alSingleton bS $ TtRef asS) ILUninterpolated)
+              [ (Tagged xS, OpDefine $ arrayDef "kriss" Nothing (Tagged aS) ReadOnly)
+              , (Tagged aS, OpDefine $ tupleDef "ref a" (alSingleton aS $ TtInt32 unbounded) ILUninterpolated)
               ])
+            (alSingleton [pathq|/ard|] $ ConstChange Nothing [WireValue @Int32 3])
+            (Map.singleton [pathq|/|] $ Map.singleton [segq|ard|] (Nothing, SoAbsent))
             mempty
-            mempty
-            mempty
-        d2 = TrpDigest
-            (Namespace xS)
-            mempty
-            mempty
-            (alFromList
-              [ ([pathq|/ass/ard/vark|], ConstChange Nothing [WireValue @Text "/bss/ban"])
-              , ([pathq|/bss/ban/ana|], ConstChange Nothing [WireValue @Text "/ass/ard"])
-              ])
-            (Map.singleton [pathq|/ass|] $ Map.singleton [segq|ard|] (Nothing, SoAbsent))
-            mempty
-      in do
-        vs' <- vsAppliesCleanly d vs
-        void $ vsAppliesCleanly d2 vs' :: IO ()
+      in void $ vsAppliesCleanly d vs :: IO ()
     it "Array" $
       let
         ars = [segq|arr|]


### PR DESCRIPTION
There are 2 bugs fixed here that combined to cause #139:

The first was that we were emptying all children of an RtContainer when applying contOps to it.

The second was that were set in a bundle and subsequently made absent in the same bundle were not being removed from the set of tainted paths.

So when the bundle came in declaring the new outputs and setting their cross references the new paths counted (correctly) as tainted, but were removed by the first issue and became uncheckable, triggering the second.