### PR TITLE
Fix namespace removal on provider revocation

### DIFF
--- a/src/Clapi/Relay.hs
+++ b/src/Clapi/Relay.hs
@@ -273,6 +273,7 @@ handleTrprd i d = runExceptT dropNamespace >>= either
       if (existing == Just i)
         then lift $ do
           updateOwners owners'
+          modifying rsVsMap $ Map.delete ns
           unsubscribeFromNs (Set.singleton ns) >>= lift . multicast . fmap Frcsd
           broadcast $ Frcrd $ FrcRootDigest $ Map.singleton ns SoAbsent
         else throwError "You're not the owner"

--- a/test/RelaySpec.hs
+++ b/test/RelaySpec.hs
@@ -108,6 +108,15 @@ spec = do
         sendFwd $ ClientData "owner1" $ Trprd $ TrprDigest fooNs
         expectSet $ nsCease fooNs <$> ["owner1", "owner2"]
 
+        -- Check that the previously defined namespace is completely gone
+        sendFwd $ ClientConnect "Subscriber" "sub"
+        expect $ [emptyRootDig "sub"]
+        subscribe fooNs (Tagged @Definition foo) "sub"
+        expect $ [ServerData "sub" $ Frcsd $ mempty {
+          frcsdErrors = Map.singleton (NamespaceSubError fooNs)
+            ["Namespace not found"] }]
+        sendFwd $ ClientDisconnect "sub"
+
         sendFwd $ ClientData "owner2" $ Trpd $ simpleClaim foo
         expectSet $ nsExists fooNs <$> ["owner1", "owner2"]
 


### PR DESCRIPTION
During my wanderings around validation, I found this case where the existing relay doesn't properly remove data when revoked by a provider.