### PR TITLE
Make *Digest into TrDigest and FrDigest GADTs

### DIFF
--- a/src/Clapi/Attributor.hs
+++ b/src/Clapi/Attributor.hs
@@ -1,4 +1,8 @@
 {-# OPTIONS_GHC -Wall -Wno-orphans #-}
+{-# LANGUAGE
+    DataKinds
+  , GADTs
+#-}
 
 module Clapi.Attributor where
 
@@ -6,18 +10,19 @@ import Control.Monad (forever)
 import Data.Bifunctor (first)
 
 import Clapi.Protocol (Protocol, waitThen, sendFwd, sendRev)
-import Clapi.Types
-  (Attributee, TrDigest(..), TrcUpdateDigest(..), DataChange(..))
+import Clapi.Types (Attributee, TrDigest(..), SomeTrDigest(..), DataChange(..))
 
 attributor
   :: (Monad m, Functor f)
-  => Attributee -> Protocol (f TrDigest) (f TrDigest) a a m ()
+  => Attributee -> Protocol (f SomeTrDigest) (f SomeTrDigest) a a m ()
 attributor u = forever $ waitThen (sendFwd . fmap attributeClient) sendRev
   where
-    attributeClient (Trcud d) = Trcud $ d{
-      trcudContOps = fmap (first modAttr) <$> trcudContOps d,
-      trcudData = attributeDc <$> trcudData d}
-    attributeClient d = d
+    attributeClient sd@(SomeTrDigest d) = case d of
+      Trcud {} -> SomeTrDigest $ d
+        { trcudContOps = fmap (first modAttr) <$> trcudContOps d
+        , trcudData = attributeDc <$> trcudData d
+        }
+      _ -> sd
     attributeDc dc = case dc of
       ConstChange ma vs -> ConstChange (modAttr ma) vs
       TimeChange m -> TimeChange $ first modAttr <$> m

--- a/src/Clapi/Util.hs
+++ b/src/Clapi/Util.hs
@@ -30,7 +30,6 @@ import Data.Foldable (Foldable, toList)
 import qualified Data.Foldable as Foldable
 import Data.List (intercalate)
 import Data.List.Split (splitOn)
-import Data.Proxy
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)

--- a/src/Clapi/Valuespace.hs
+++ b/src/Clapi/Valuespace.hs
@@ -55,7 +55,8 @@ import Clapi.Types.Definitions
   , DefName, childEditableFor, childTypeFor)
 import Clapi.Types.Digests
   ( TpId, DefOp(..), isUndef, ContOps, DataChange(..), isRemove, DataDigest
-  , TrpDigest(..), trpdRemovedPaths, TrcUpdateDigest(..), CreateOp(..), Creates
+  , TrDigest(..)
+  , TrpDigest, trpdRemovedPaths, TrcUpdateDigest, CreateOp(..), Creates
   , DataErrorIndex(..))
 import Clapi.Types.Path
   (Seg, Path, pattern (:/), pattern Root, Placeholder, childPaths)
@@ -340,14 +341,14 @@ processToRelayProviderDigest trpd vs =
     tas = foldl removeTamSubtree (vsTyAssns vs) $ trpdRemovedPaths trpd
     getPathsWithType s = Dependencies.lookupRev s tas
     redefdPaths = mconcat $
-      fmap getPathsWithType $ Map.keys $ trpdDefinitions trpd
+      fmap getPathsWithType $ Map.keys $ trpdDefs trpd
     updatedPaths = opsTouched (trpdContOps trpd) $ trpdData trpd
     tpRemovals :: DataChange -> Set TpId
     tpRemovals (ConstChange {})= mempty
     tpRemovals (TimeChange m) = Map.keysSet $ Map.filter (isRemove . snd) m
     xrefs' = Map.foldlWithKey' (\x r ts -> removeXrefsTps r ts x) (vsXrefs vs) $
       fmap tpRemovals $ alToMap $ trpdData trpd
-    defs' = updateNsDefs (trpdDefinitions trpd) $ vsTyDefs vs
+    defs' = updateNsDefs (trpdDefs trpd) $ vsTyDefs vs
     postDefs' = updateNsDefs (trpdPostDefs trpd) $ vsPostDefs vs
     (updateErrs, tree') = Tree.updateTreeWithDigest
         (trpdContOps trpd) (trpdData trpd) (vsTree vs)

--- a/test/SerialisationProtocolSpec.hs
+++ b/test/SerialisationProtocolSpec.hs
@@ -13,7 +13,7 @@ import qualified Data.Map.Mol as Mol
 
 import Instances ()
 
-import Clapi.Types (FrDigest(..), FrpErrorDigest(..), DataErrorIndex(..))
+import Clapi.Types (FrDigest(..), SomeFrDigest(..), DataErrorIndex(..))
 import Clapi.Protocol
   ((<<->), sendRev, sendFwd, waitThenFwdOnly, waitThenRevOnly, runEffect)
 import Clapi.Serialisation ()
@@ -23,8 +23,7 @@ spec :: Spec
 spec = it "Packetised round trip" $
     runEffect $ chunkyEcho <<-> serialiser <<-> test
   where
-    msg :: FrDigest
-    msg = Frped $ FrpErrorDigest $ Mol.singleton GlobalError "part of test"
+    msg = SomeFrDigest $ Frped $ Mol.singleton GlobalError "part of test"
     chunkyEcho = forever $ waitThenRevOnly $ \c ->
       let (c0, c1) = B.splitAt (B.length c `div` 2) c in
         sendFwd c0 >> sendFwd c1

--- a/test/SerialisationSpec.hs
+++ b/test/SerialisationSpec.hs
@@ -17,7 +17,7 @@ import Test.QuickCheck (property, Property, counterexample)
 import Blaze.ByteString.Builder (toByteString)
 import Data.Attoparsec.ByteString (parseOnly, endOfInput)
 
-import Clapi.Types (TrDigest(..), FrDigest(..))
+import Clapi.Types (SomeTrDigest(..), SomeFrDigest(..))
 import Clapi.Serialisation (Encodable(..), Decodable(..))
 
 import Arbitrary ()
@@ -52,8 +52,8 @@ spec :: Spec
 spec = do
   describe "ToRelayDigest" $
     it "should survive a round trip via binary" $ property $
-      \(b :: TrDigest) -> propDigestRoundTrip b
+      \(b :: SomeTrDigest) -> propDigestRoundTrip b
 
   describe "FromRelayDigest" $
     it "should survive a round trip via binary" $ property $
-      \(b :: FrDigest) -> propDigestRoundTrip b
+      \(b :: SomeFrDigest) -> propDigestRoundTrip b


### PR DESCRIPTION
So that we can make it a bit more like `Definition`, where we removed the wrapping sum type and added existentials instead. I _think_ that this way is at least a bit more expressive. @foolswood said it would be helpful to be able to have type signatures that matched on the lifted new `OriginatorRole` and `DigestAction` types so that one might be able to avoid writing cases for stuff one didn't want to handle.