### PR TITLE
Expose Eq instances for *Definition

### DIFF
--- a/src/Clapi/Types/Definitions.hs
+++ b/src/Clapi/Types/Definitions.hs
@@ -14,6 +14,7 @@ import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail(..))
 import Data.Tagged (Tagged)
 import Data.Text (Text)
+import Data.Type.Equality (TestEquality(..), (:~:)(..))
 
 import Data.Maybe.Clapi (note)
 
@@ -55,10 +56,22 @@ data Definition (mt :: MetaType) where
     , arrDefChildEd :: Editability
     } -> Definition 'Array
 deriving instance Show (Definition mt)
+deriving instance Eq (Definition mt)
+
+instance TestEquality Definition where
+  TupleDef {} `testEquality` TupleDef {} = Just Refl
+  StructDef {} `testEquality` StructDef {} = Just Refl
+  ArrayDef {} `testEquality` ArrayDef {} = Just Refl
+  _ `testEquality` _ = Nothing
 
 data SomeDefinition where
   SomeDefinition :: Definition mt -> SomeDefinition
 deriving instance Show SomeDefinition
+
+instance Eq SomeDefinition where
+  SomeDefinition d1 == SomeDefinition d2 = case testEquality d1 d2 of
+    Just Refl -> d1 == d2
+    Nothing -> False
 
 withDefinition :: (forall mt. Definition mt -> r) -> SomeDefinition -> r
 withDefinition f (SomeDefinition d) = f d

--- a/test/Instances.hs
+++ b/test/Instances.hs
@@ -20,20 +20,6 @@ import Clapi.Types.SequenceOps (SequenceOp(..))
 import Clapi.Valuespace
 
 
-instance TestEquality Definition where
-  TupleDef {} `testEquality` TupleDef {} = Just Refl
-  StructDef {} `testEquality` StructDef {} = Just Refl
-  ArrayDef {} `testEquality` ArrayDef {} = Just Refl
-  _ `testEquality` _ = Nothing
-
-
-deriving instance Eq (Definition mt)
-
-instance Eq SomeDefinition where
-  SomeDefinition d1 == SomeDefinition d2 = case testEquality d1 d2 of
-    Just Refl -> d1 == d2
-    Nothing -> False
-
 deriving instance Eq FrDigestType
 
 deriving instance Eq (TrDigest r a)


### PR DESCRIPTION
because whilst they're not needed internally in Clapi, they _are_ needed for testing in Cape, and we can't expose code from the tests for others to use, AFAIK.